### PR TITLE
Fix GitHub Pages blank page by setting Vite base path to /eva/

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-Dpe1isWV.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BHDcHXrI.css">
+    <script type="module" crossorigin src="/eva/assets/index-Dpe1isWV.js"></script>
+    <link rel="stylesheet" crossorigin href="/eva/assets/index-BHDcHXrI.css">
   </head>
   <body>
     <div id="root"></div>

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: '/',
+  base: '/eva/',
   build: {
     outDir: '../docs',
     emptyOutDir: false,


### PR DESCRIPTION
The site at servicenow.github.io/eva/ was blank because assets were referenced at /assets/ instead of /eva/assets/. Updated vite.config.ts base from '/' to '/eva/' and rebuilt docs/.