### PR TITLE
Yield content alongside tool calls

### DIFF
--- a/src/eva/assistant/agentic/audit_log.py
+++ b/src/eva/assistant/agentic/audit_log.py
@@ -202,7 +202,7 @@ class AuditLog:
                 wall-clock captured at the first ``audio_delta`` so the audit
                 log reflects when the assistant actually started responding.
         """
-        if content and not tool_calls:
+        if content:
             entry = {
                 "value": content,
                 "displayName": "Bot",
@@ -213,12 +213,10 @@ class AuditLog:
             }
             self.transcript.append(entry)
 
-        # With tool calls, we save an empty content regardless because it is never returned to the client.
-        # TODO Implement returning the content to the client while tool calls are in progress
         self.conversation_messages.append(
             ConversationMessage(
                 role=MessageRole.ASSISTANT,
-                content="" if tool_calls else content,
+                content=content,
                 tool_calls=tool_calls,
             )
         )

--- a/src/eva/assistant/agentic/system.py
+++ b/src/eva/assistant/agentic/system.py
@@ -278,12 +278,14 @@ class AgenticSystem:
                     yield GENERIC_ERROR
                 return
 
+            if response_content:
+                logger.info(f"💬 Assistant LLM response: {response_content}")
+                yield response_content
+
+            self.audit_log.append_assistant_output(content=response_content, tool_calls=tool_calls_dicts or None)
+
             if not tool_calls_dicts:
                 # No tool calls, this is the final response
-                if response_content:
-                    logger.info(f"💬 Assistant LLM response: {response_content}")
-                    yield response_content
-                    self.audit_log.append_assistant_output(response_content)
                 return
 
             messages.append(
@@ -293,8 +295,6 @@ class AgenticSystem:
                     "tool_calls": tool_calls_dicts,
                 }
             )
-
-            self.audit_log.append_assistant_output(content=response_content, tool_calls=tool_calls_dicts)
 
             # Execute each tool call
             for tool_call in response_tool_calls:

--- a/src/eva/assistant/agentic/system.py
+++ b/src/eva/assistant/agentic/system.py
@@ -283,69 +283,69 @@ class AgenticSystem:
                     yield response_content
                     self.audit_log.append_assistant_output(response_content)
                 return
-            else:
-                messages.append(
-                    {
-                        "role": "assistant",
-                        "content": response_content,
-                        "tool_calls": tool_calls_dicts,
-                    }
-                )
 
-                self.audit_log.append_assistant_output(content=response_content, tool_calls=tool_calls_dicts)
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": response_content,
+                    "tool_calls": tool_calls_dicts,
+                }
+            )
 
-                # Execute each tool call
-                for tool_call in response_tool_calls:
-                    tool_name = _clean_tool_name(tool_call.function.name)
-                    try:
-                        # TODO Consider this a model error instead of handling this gracefully
-                        params = json.loads(tool_call.function.arguments)
-                    except json.JSONDecodeError:
-                        params = {}
+            self.audit_log.append_assistant_output(content=response_content, tool_calls=tool_calls_dicts)
 
-                    # Log tool call
-                    logger.info(f"🔧 Tool call: {tool_name}")
-                    logger.info(f"   Parameters: {json.dumps(params, indent=2)}")
+            # Execute each tool call
+            for tool_call in response_tool_calls:
+                tool_name = _clean_tool_name(tool_call.function.name)
+                try:
+                    # TODO Consider this a model error instead of handling this gracefully
+                    params = json.loads(tool_call.function.arguments)
+                except json.JSONDecodeError:
+                    params = {}
 
-                    # Special handling for transfer to live agent
-                    if tool_name == "transfer_to_agent":
-                        transfer_message = "Transferring you to a live agent. Please wait."
-                        self.audit_log.append_tool_call(
-                            tool_name=tool_name,
-                            parameters=params,
-                            response={"status": "transfer_initiated"},
-                        )
+                # Log tool call
+                logger.info(f"🔧 Tool call: {tool_name}")
+                logger.info(f"   Parameters: {json.dumps(params, indent=2)}")
 
-                        logger.info(f"🔀 Transfer initiated: {transfer_message}")
-                        yield transfer_message
-                        self.audit_log.append_assistant_output(transfer_message)
-                        return
-
-                    result = await self.tool_handler.execute(tool_name, params)
-
-                    if result.get("status") == "error":
-                        logger.warning(f"❌ Tool error: {tool_name} - {result.get('message', 'Unknown error')}")
-                    else:
-                        logger.info(f"✅ Tool response: {tool_name}")
-                        logger.info(f"   Result: {json.dumps(result, indent=2)}")
-
+                # Special handling for transfer to live agent
+                if tool_name == "transfer_to_agent":
+                    transfer_message = "Transferring you to a live agent. Please wait."
                     self.audit_log.append_tool_call(
                         tool_name=tool_name,
                         parameters=params,
-                        response=result,
+                        response={"status": "transfer_initiated"},
                     )
 
-                    # Add tool response to messages
-                    tool_content = json.dumps(result)
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": tool_call.id,
-                            "content": tool_content,
-                        }
-                    )
+                    logger.info(f"🔀 Transfer initiated: {transfer_message}")
+                    yield transfer_message
+                    self.audit_log.append_assistant_output(transfer_message)
+                    return
 
-                    self.audit_log.append_tool_message(tool_call_id=tool_call.id, content=tool_content)
+                result = await self.tool_handler.execute(tool_name, params)
+
+                if result.get("status") == "error":
+                    logger.warning(f"❌ Tool error: {tool_name} - {result.get('message', 'Unknown error')}")
+                else:
+                    logger.info(f"✅ Tool response: {tool_name}")
+                    logger.info(f"   Result: {json.dumps(result, indent=2)}")
+
+                self.audit_log.append_tool_call(
+                    tool_name=tool_name,
+                    parameters=params,
+                    response=result,
+                )
+
+                # Add tool response to messages
+                tool_content = json.dumps(result)
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": tool_content,
+                    }
+                )
+
+                self.audit_log.append_tool_message(tool_call_id=tool_call.id, content=tool_content)
 
     def get_stats(self) -> dict[str, Any]:
         """Get conversation statistics."""

--- a/src/eva/assistant/agentic/system.py
+++ b/src/eva/assistant/agentic/system.py
@@ -275,7 +275,15 @@ class AgenticSystem:
                     yield GENERIC_ERROR
                 return
 
-            if tool_calls_dicts:
+            if not tool_calls_dicts:
+                # No tool calls, this is the final response
+                if response_content:
+                    response_content = response_content.strip()
+                    logger.info(f"💬 Assistant LLM response: {response_content}")
+                    yield response_content
+                    self.audit_log.append_assistant_output(response_content)
+                return
+            else:
                 messages.append(
                     {
                         "role": "assistant",
@@ -338,14 +346,6 @@ class AgenticSystem:
                     )
 
                     self.audit_log.append_tool_message(tool_call_id=tool_call.id, content=tool_content)
-            else:
-                # No tool calls, this is the final response
-                if response_content:
-                    response_content = response_content.strip()
-                    logger.info(f"💬 Assistant LLM response: {response_content}")
-                    yield response_content
-                    self.audit_log.append_assistant_output(response_content)
-                return
 
     def get_stats(self) -> dict[str, Any]:
         """Get conversation statistics."""

--- a/src/eva/assistant/agentic/system.py
+++ b/src/eva/assistant/agentic/system.py
@@ -186,6 +186,9 @@ class AgenticSystem:
                 ]
 
                 response_content = getattr(response, "content", "") or (response if isinstance(response, str) else "")
+                if response_content:
+                    response_content = response_content.strip()
+
                 response_tool_calls_for_stats = (
                     [
                         {"name": tool["function"]["name"], "arguments": tool["function"]["arguments"]}
@@ -278,7 +281,6 @@ class AgenticSystem:
             if not tool_calls_dicts:
                 # No tool calls, this is the final response
                 if response_content:
-                    response_content = response_content.strip()
                     logger.info(f"💬 Assistant LLM response: {response_content}")
                     yield response_content
                     self.audit_log.append_assistant_output(response_content)

--- a/tests/unit/assistant/test_agentic_system.py
+++ b/tests/unit/assistant/test_agentic_system.py
@@ -146,7 +146,7 @@ class TestProcessQueryWithToolCall:
         async for msg in system.process_query("Check reservation ABC123"):
             responses.append(msg)
 
-        assert responses == ["Your reservation ABC123 is confirmed."]
+        assert responses == ["What if there is text here", "Your reservation ABC123 is confirmed."]
 
         # Verify tool was executed with correct params
         tool_handler.execute.assert_awaited_once_with("get_reservation", {"confirmation_number": "ABC123"})
@@ -154,21 +154,30 @@ class TestProcessQueryWithToolCall:
         # Verify LLM was called twice (tool call + final response)
         assert llm_client.complete.await_count == 2
 
-        # Verify transcript
+        # Verify transcript — content alongside tool calls now appears as an assistant entry
         transcript = audit_log.transcript
         message_types = [e["message_type"] for e in transcript]
-        assert message_types == ["user", "llm_call", "tool_call", "tool_response", "llm_call", "assistant"]
+        assert message_types == [
+            "user",
+            "llm_call",
+            "assistant",
+            "tool_call",
+            "tool_response",
+            "llm_call",
+            "assistant",
+        ]
         assert transcript[0]["value"] == "Check reservation ABC123"
-        assert transcript[2]["value"]["tool"] == "get_reservation"
-        assert transcript[3]["value"]["response"]["status"] == "success"
-        assert transcript[5]["value"] == "Your reservation ABC123 is confirmed."
+        assert transcript[2]["value"] == "What if there is text here"
+        assert transcript[3]["value"]["tool"] == "get_reservation"
+        assert transcript[4]["value"]["response"]["status"] == "success"
+        assert transcript[6]["value"] == "Your reservation ABC123 is confirmed."
 
-        # Verify conversation messages
+        # Verify conversation messages — content is preserved even with tool calls
         assert _conv_to_dicts(audit_log.get_conversation_messages()) == [
             {"role": "user", "content": "Check reservation ABC123"},
             {
                 "role": "assistant",
-                "content": "",
+                "content": "What if there is text here",
                 "tool_calls": [
                     {
                         "id": "call_1",


### PR DESCRIPTION
I recommend reviewing the commits one by one:

* This doesn't change anything; it just makes the diff of the following commit clearer.
  - [Flip the `if`/`else`](https://github.com/ServiceNow/eva/pull/49/commits/1abd59ea64f7c4ed260d4e2678fa630dfcd0b0c9) 
  - [Unindent by removing the `else` after the `return`](https://github.com/ServiceNow/eva/pull/49/commits/d37b38a2f15809577704f42028796ca3449b4c03) 
* [Strip content before checking if it is truthy](https://github.com/ServiceNow/eva/pull/49/commits/cd79c85c814bc288cf5f7b5fa4d452d63255ffb8)
* [Yield content alongside tool calls](https://github.com/ServiceNow/eva/pull/49/commits/672973058e517a3812d6baffe2c02881ea161b40)