### PR TITLE
make model required for all services

### DIFF
--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -412,19 +412,22 @@ def create_realtime_llm_service(
     if model_lower.startswith("openai"):
         session_properties = get_openai_session_properties(system_prompt, params, pipecat_tools)
         if audit_log is not None:
-            logger.info(
-                f"Using InstrumentedRealtimeLLMService for audit log interception: openai: {params.get('model')}"
-            )
+            logger.info(f"Using InstrumentedRealtimeLLMService for audit log interception: openai: {params['model']}")
             return InstrumentedRealtimeLLMService(
-                model=params.get("model"),
+                settings=OpenAIRealtimeLLMService.Settings(
+                    model=params["model"],
+                    session_properties=session_properties,
+                ),
                 audit_log=audit_log,
                 api_key=params["api_key"],
-                session_properties=session_properties,
             )
 
         return OpenAIRealtimeLLMService(
             api_key=params["api_key"],
-            session_properties=session_properties,
+            settings=OpenAIRealtimeLLMService.Settings(
+                model=params["model"],
+                session_properties=session_properties,
+            ),
         )
     elif model_lower.startswith("azure") or model_lower.startswith("gpt-realtime"):
         #
@@ -438,17 +441,21 @@ def create_realtime_llm_service(
         if audit_log is not None:
             logger.info("Using InstrumentedRealtimeLLMService for audit log interception")
             service = InstrumentedRealtimeLLMService(
-                model=params.get("model"),
                 audit_log=audit_log,
                 api_key=params["api_key"],
                 base_url=url,
                 session_properties=session_properties,
+                settings=OpenAIRealtimeLLMService.Settings(
+                    model=params["model"],
+                    session_properties=session_properties,
+                ),
             )
             InstrumentedRealtimeLLMService._connect = override__connect  # azure realtime connect
             return service
 
         return OpenAIRealtimeLLMService(
             api_key=params["api_key"],
+            model=params["model"],
             base_url=url,
             session_properties=session_properties,
         )
@@ -461,6 +468,7 @@ def create_realtime_llm_service(
                 temperature=0.3,
                 max_duration=datetime.timedelta(minutes=6),
                 voice=params.get("voice", "03e20d03-35e4-43c4-bb18-9b18a2cd3086"),
+                model=params["model"],
             ),
             one_shot_selected_tools=pipecat_tools,
         )

--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -82,9 +82,9 @@ class PipelineConfig(BaseModel):
     def pipeline_parts(self) -> dict[str, str]:
         """Component names for this pipeline."""
         return {
-            "stt": _param_alias(self.stt_params) or self.stt,
+            "stt": _param_alias(self.stt_params),
             "llm": self.llm,
-            "tts": _param_alias(self.tts_params) or self.tts,
+            "tts": _param_alias(self.tts_params),
         }
 
     @model_validator(mode="before")
@@ -307,9 +307,6 @@ class RunConfig(BaseSettings):
         "EVA_METRICS_TO_RUN": "EVA_METRICS",
     }
 
-    # Providers that manage their own model/key resolution (e.g. WebSocket-based)
-    _SKIP_PARAMS_VALIDATION: ClassVar[set[str]] = {"nvidia"}
-
     # Maps *_params field names to their provider field for env override logic
     _PARAMS_TO_PROVIDER: ClassVar[dict[str, str]] = {
         "stt_params": "stt",
@@ -503,7 +500,7 @@ class RunConfig(BaseSettings):
             self._validate_service_params("audio_llm", self.model.audio_llm, required_keys, self.model.audio_llm_params)
         elif isinstance(self.model, SpeechToSpeechConfig):
             # api_key is required, some s2s services don't require model
-            self._validate_service_params("S2S", self.model.s2s, ["api_key"], self.model.s2s_params)
+            self._validate_service_params("S2S", self.model.s2s, required_keys, self.model.s2s_params)
         return self
 
     @model_validator(mode="after")
@@ -518,8 +515,6 @@ class RunConfig(BaseSettings):
         cls, service: str, provider: str, required_keys: list[str], params: dict[str, Any]
     ) -> None:
         """Validate that STT/TTS params contain required keys."""
-        if provider.lower() in cls._SKIP_PARAMS_VALIDATION:
-            return
         missing = [key for key in required_keys if key not in params]
         if missing:
             missing_str = " and ".join(f'"{k}"' for k in missing)

--- a/tests/unit/models/test_config_models.py
+++ b/tests/unit/models/test_config_models.py
@@ -57,7 +57,7 @@ _BASE_ENV = _EVA_MODEL_LIST_ENV | {
 }
 _S2S_ENV = _EVA_MODEL_LIST_ENV | {
     "EVA_MODEL__S2S": "gpt-realtime-mini",
-    "EVA_MODEL__S2S_PARAMS": json.dumps({"api_key": ""}),
+    "EVA_MODEL__S2S_PARAMS": json.dumps({"api_key": "", "model": "test"}),
 }
 
 
@@ -75,6 +75,12 @@ def _config(
 
     with patch.dict(os.environ, env_vars or {}, clear=True):
         return RunConfig(_env_file=env_file, _cli_parse_args=cli_args, **kwargs)
+
+
+def _load_json_into_runconfig(json_str: str) -> RunConfig:
+    """Load RunConfig from JSON with isolated environment (no real env vars)."""
+    with patch.dict(os.environ, {}, clear=True):
+        return RunConfig.model_validate_json(json_str)
 
 
 class TestRunConfig:
@@ -193,7 +199,7 @@ class TestRunConfig:
         """Redacted secrets are restored from a live config for both model and model_list."""
         config = _config(env_vars=_BASE_ENV)
         dumped_json = config.model_dump_json()
-        loaded = RunConfig.model_validate_json(dumped_json)
+        loaded = _load_json_into_runconfig(dumped_json)
 
         # Everything is redacted after round-trip
         assert loaded.model.stt_params["api_key"] == "***"
@@ -214,11 +220,11 @@ class TestRunConfig:
         assert loaded.model_list[2]["litellm_params"]["aws_access_key_id"] == "must_be_redacted"
         assert loaded.model_list[2]["litellm_params"]["aws_secret_access_key"] == "must_be_redacted"
 
-    def test_apply_env_overrides_provider_mismatch(self):
-        """Restoring secrets fails if the STT/TTS provider changed."""
+    def test_apply_env_overrides_provider_mismatch(self, caplog):
+        """Restoring secrets warns (but succeeds) if the STT/TTS provider changed."""
         config = _config(env_vars=_BASE_ENV)
         dumped_json = config.model_dump_json()
-        loaded = RunConfig.model_validate_json(dumped_json)
+        loaded = _load_json_into_runconfig(dumped_json)
 
         live = _config(
             env_vars=_BASE_ENV
@@ -227,8 +233,11 @@ class TestRunConfig:
                 "EVA_MODEL__STT_PARAMS": json.dumps({"api_key": "k", "model": "whisper-1"}),
             }
         )
-        with pytest.raises(ValueError, match=r"saved stt='deepgram'.*current environment has stt='openai_whisper'"):
+        with caplog.at_level("WARNING", logger="eva.models.config"):
             loaded.apply_env_overrides(live)
+        assert "Provider mismatch for stt_params" in caplog.text
+        assert "deepgram" in caplog.text
+        assert "openai_whisper" in caplog.text
 
     def test_apply_env_overrides_alias_mismatch(self):
         """Restoring secrets fails if the alias changed."""
@@ -239,7 +248,7 @@ class TestRunConfig:
             }
         )
         dumped_json = config.model_dump_json()
-        loaded = RunConfig.model_validate_json(dumped_json)
+        loaded = _load_json_into_runconfig(dumped_json)
 
         live = _config(
             env_vars=_BASE_ENV
@@ -257,7 +266,7 @@ class TestRunConfig:
         """Restoring secrets warns (but succeeds) if the STT/TTS model changed."""
         config = _config(env_vars=_BASE_ENV)
         dumped_json = config.model_dump_json()
-        loaded = RunConfig.model_validate_json(dumped_json)
+        loaded = _load_json_into_runconfig(dumped_json)
 
         live = _config(env_vars=_BASE_ENV | {"EVA_MODEL__TTS_PARAMS": json.dumps({"api_key": "k", "model": "sonic-2"})})
         with caplog.at_level("WARNING", logger="eva.models.config"):
@@ -273,7 +282,7 @@ class TestRunConfig:
         }
         config = _config(env_vars=saved_env)
         dumped_json = config.model_dump_json()
-        loaded = RunConfig.model_validate_json(dumped_json)
+        loaded = _load_json_into_runconfig(dumped_json)
 
         # Live env has a different url
         live_env = _BASE_ENV | {
@@ -292,7 +301,7 @@ class TestRunConfig:
         """Url from live env is added even if the saved config didn't have one."""
         config = _config(env_vars=_BASE_ENV)
         dumped_json = config.model_dump_json()
-        loaded = RunConfig.model_validate_json(dumped_json)
+        loaded = _load_json_into_runconfig(dumped_json)
 
         live_env = _BASE_ENV | {
             "EVA_MODEL__STT_PARAMS": json.dumps({"api_key": "k", "model": "nova-2", "url": "wss://new-host/stt"}),
@@ -306,7 +315,7 @@ class TestRunConfig:
         """Restoring secrets fails if a saved LLM deployment is missing from the live model_list."""
         config = _config(env_vars=_BASE_ENV)
         dumped_json = config.model_dump_json()
-        loaded = RunConfig.model_validate_json(dumped_json)
+        loaded = _load_json_into_runconfig(dumped_json)
 
         # Live config has a different model_list (only one deployment, different name)
         different_model_list = [
@@ -447,20 +456,6 @@ class TestRunConfig:
                 }
             )
 
-    def test_nvidia_stt_skips_params_validation(self):
-        """NVIDIA STT skips api_key/model validation (uses url-based config)."""
-        config = _config(
-            env_vars=_EVA_MODEL_LIST_ENV
-            | {
-                "EVA_MODEL__LLM": "gpt-5.2",
-                "EVA_MODEL__STT": "nvidia",
-                "EVA_MODEL__TTS": "cartesia",
-                "EVA_MODEL__STT_PARAMS": json.dumps({"url": "ws://localhost:8000"}),
-                "EVA_MODEL__TTS_PARAMS": json.dumps({"api_key": "k", "model": "sonic"}),
-            }
-        )
-        assert config.model.stt == "nvidia"
-
 
 class TestDefaults:
     """Verify default values match expectations."""
@@ -547,14 +542,14 @@ class TestDeprecatedEnvVars:
                 _S2S_ENV,
                 "REALTIME_MODEL_PARAMS",
                 "EVA_MODEL__S2S_PARAMS",
-                {"api_key": "k"},
+                {"api_key": "k", "model": "model"},
                 lambda c: c.model.s2s_params,
             ),
             (
                 _S2S_ENV,
                 "EVA_MODEL__REALTIME_MODEL_PARAMS",
                 "EVA_MODEL__S2S_PARAMS",
-                {"api_key": "k"},
+                {"api_key": "k", "model": "model"},
                 lambda c: c.model.s2s_params,
             ),
             (
@@ -816,7 +811,7 @@ class TestSpeechToSpeechConfig:
             env_vars=_EVA_MODEL_LIST_ENV
             | {
                 "EVA_MODEL__S2S": "gpt-realtime-mini",
-                "EVA_MODEL__S2S_PARAMS": json.dumps({"api_key": ""}),
+                "EVA_MODEL__S2S_PARAMS": json.dumps({"api_key": "", "model": "gpt-realtime-mini"}),
             }
         )
         assert isinstance(config.model, SpeechToSpeechConfig)
@@ -826,17 +821,25 @@ class TestSpeechToSpeechConfig:
         """--s2s-model selects SpeechToSpeechConfig."""
         config = _config(
             env_vars=_EVA_MODEL_LIST_ENV,
-            cli_args=["--model.s2s", "gemini_live", "--model.s2s-params", '{"api_key": "test-key"}'],
+            cli_args=[
+                "--model.s2s",
+                "gemini_live",
+                "--model.s2s-params",
+                '{"api_key": "test-key", "model": "gemini_live"}',
+            ],
         )
         assert isinstance(config.model, SpeechToSpeechConfig)
         assert config.model.s2s == "gemini_live"
-        assert config.model.s2s_params == {"api_key": "test-key"}
+        assert config.model.s2s_params == {"api_key": "test-key", "model": "gemini_live"}
 
     def test_s2s_config_with_params(self):
         """S2S params are passed through."""
         config = _config(
             env_vars=_EVA_MODEL_LIST_ENV,
-            model={"s2s": "gpt-realtime-mini", "s2s_params": {"voice": "alloy", "api_key": "key_1"}},
+            model={
+                "s2s": "gpt-realtime-mini",
+                "s2s_params": {"voice": "alloy", "api_key": "key_1", "model": "gpt-realtime-mini"},
+            },
         )
         assert isinstance(config.model, SpeechToSpeechConfig)
-        assert config.model.s2s_params == {"voice": "alloy", "api_key": "key_1"}
+        assert config.model.s2s_params == {"voice": "alloy", "api_key": "key_1", "model": "gpt-realtime-mini"}


### PR DESCRIPTION
- make model required for all services (now include s2s and nvidia on baseten)
- fix tests
  - add model field for s2s env tests
  - don't use live env vars for `test_apply_env_overrides` tests
  - update provider warning test to check for warning instead of ValueError