### PR TITLE
Add submetrics for more metrics

### DIFF
--- a/apps/analysis.py
+++ b/apps/analysis.py
@@ -77,7 +77,22 @@ _CATEGORY_COLORS = {
     "Other": "#AAAAAA",
 }
 
-_NON_NORMALIZED_METRICS = {"response_speed"}
+_NON_NORMALIZED_METRICS = {"response_speed", "tool_call_validity__num_tool_calls"}
+
+# Axis title + hover suffix for non-normalized metrics. Sub-metrics fall back to their parent's entry.
+_NON_NORMALIZED_UNITS: dict[str, tuple[str, str]] = {
+    "response_speed": ("Seconds", "s"),
+    "tool_call_validity__num_tool_calls": ("Count", ""),
+}
+
+
+def _non_normalized_unit(name: str) -> tuple[str, str]:
+    """Return (x-axis title, hover suffix) for a non-normalized metric."""
+    if name in _NON_NORMALIZED_UNITS:
+        return _NON_NORMALIZED_UNITS[name]
+    parent = name.split("__", 1)[0]
+    return _NON_NORMALIZED_UNITS.get(parent, ("Value", ""))
+
 
 # Prefix shown in front of metric labels when the metric is lower-is-better.
 _LOWER_IS_BETTER_PREFIX = "↓ "
@@ -1280,6 +1295,7 @@ def render_run_overview(run_dir: Path):
         for m, stats in standalone_data.items():
             display_name = _format_metric_name(m)
             cat = _METRIC_GROUP.get(m, "Other")
+            axis_title, suffix = _non_normalized_unit(m)
             fig = go.Figure()
             fig.add_trace(
                 go.Bar(
@@ -1296,17 +1312,17 @@ def render_run_overview(run_dir: Path):
                     },
                     hovertemplate=(
                         f"<b>{display_name}</b><br>"
-                        "Mean: %{x:.3f}s<br>"
-                        f"Std: {stats['std']:.3f}s<br>"
-                        f"Min: {stats['min']:.3f}s<br>"
-                        f"Max: {stats['max']:.3f}s<br>"
+                        f"Mean: %{{x:.3f}}{suffix}<br>"
+                        f"Std: {stats['std']:.3f}{suffix}<br>"
+                        f"Min: {stats['min']:.3f}{suffix}<br>"
+                        f"Max: {stats['max']:.3f}{suffix}<br>"
                         f"n={stats['count']}"
                         "<extra></extra>"
                     ),
                 )
             )
             fig.update_layout(
-                xaxis_title="Seconds",
+                xaxis_title=axis_title,
                 yaxis={"categoryorder": "array", "categoryarray": [display_name]},
                 height=150,
                 margin={"l": 10, "r": 10, "t": 10, "b": 40},

--- a/apps/analysis.py
+++ b/apps/analysis.py
@@ -2048,7 +2048,7 @@ def _get_run_dirs():
 
     run_dirs = [rd for od in output_dirs for rd in get_run_directories(od)]
 
-    latest_only = st.sidebar.toggle("Latest run per system only", value=True)
+    latest_only = st.sidebar.toggle("Latest run per system only", value=True, key="latest_only", bind="query-params")
     if latest_only:
         run_dirs = filter_latest_runs(run_dirs)
 

--- a/apps/analysis.py
+++ b/apps/analysis.py
@@ -248,6 +248,18 @@ def _load_metrics_summary(run_dir: Path) -> dict:
     return {}
 
 
+def _load_evaluation_summary(run_dir: Path) -> dict:
+    """Load evaluation_summary.json for a run."""
+    path = run_dir / "evaluation_summary.json"
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
 def format_transcript(transcript_path: Path) -> pd.DataFrame:
     """Load and format transcript.jsonl as a DataFrame."""
     if not transcript_path.exists():
@@ -1020,6 +1032,8 @@ def render_cross_run_comparison(run_dirs: list[Path]):
         run_name = run_dir.name
         run_config = run_configs[run_name]
         metrics_summary = _load_metrics_summary(run_dir)
+        eval_summary = _load_evaluation_summary(run_dir)
+        simulation = eval_summary.get("simulation") or {}
 
         # Try metrics_summary.json first, fall back to per-record loading
         if metrics_summary and "per_metric" in metrics_summary:
@@ -1028,6 +1042,7 @@ def render_cross_run_comparison(run_dirs: list[Path]):
             all_metric_names.update(metric_names)
             model_details = _extract_model_details(run_config)
             system_name, run_timestamp = _get_system_and_timestamp(run_name, run_config)
+            data_quality = metrics_summary.get("data_quality") or {}
             summary: dict = {
                 "run": run_name,
                 "run_output_dir": str(run_dir.parent),
@@ -1035,6 +1050,9 @@ def render_cross_run_comparison(run_dirs: list[Path]):
                 "system_name": system_name,
                 "run_timestamp": run_timestamp,
                 "records": metrics_summary.get("total_records", 0),
+                "conversation_failures": simulation.get("failed_records"),
+                "records_with_errors": data_quality.get("records_with_errors"),
+                "metrics_with_errors": data_quality.get("metrics_with_errors") or {},
                 "pipeline_type": _classify_pipeline_type(run_config),
                 **model_details,
             }
@@ -1072,6 +1090,9 @@ def render_cross_run_comparison(run_dirs: list[Path]):
                 "system_name": system_name,
                 "run_timestamp": run_timestamp,
                 "records": len(df),
+                "conversation_failures": simulation.get("failed_records"),
+                "records_with_errors": None,
+                "metrics_with_errors": {},
                 "pipeline_type": _classify_pipeline_type(run_config),
                 **model_details,
             }
@@ -1105,6 +1126,17 @@ def render_cross_run_comparison(run_dirs: list[Path]):
         _render_eva_scatter_plot(scatter_data)
 
     st.markdown("#### Mean Metrics per Run")
+
+    def _safe_int(value: object) -> int:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return 0
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    def _has_any_errors(row: pd.Series) -> bool:
+        return bool(_safe_int(row.get("records_with_errors")) or _safe_int(row.get("conversation_failures")))
 
     # Grouped bar chart: Accuracy/Experience metrics + EVA composites
     bar_metrics = [m for m in ordered_metrics if _METRIC_GROUP.get(m) in _BAR_CHART_CATEGORIES]
@@ -1147,6 +1179,10 @@ def render_cross_run_comparison(run_dirs: list[Path]):
         "run_output_dir": "Output Dir",
         "records": "# Records",
     }
+    summary_df["system_name"] = [
+        f"{name} ⚠️" if _has_any_errors(row) else name
+        for name, (_, row) in zip(summary_df["system_name"], summary_df.iterrows())
+    ]
     link_series = "/run_overview?output_dir=" + summary_df["run_output_dir"] + "&run=" + summary_df["run"]
 
     def _show_subtable(heading: str, composites: list, metrics: list) -> None:
@@ -1170,6 +1206,38 @@ def render_cross_run_comparison(run_dirs: list[Path]):
     _show_subtable("Accuracy Metrics (EVA-A)", eva_a_composites, accuracy_metrics)
     _show_subtable("Experience Metrics (EVA-X)", eva_x_composites, experience_metrics)
     _show_subtable("Diagnostic & Other Metrics", [], other_metrics)
+
+    error_rows = []
+    for _, row in summary_df.iterrows():
+        total = _safe_int(row.get("records"))
+        conv_failures = _safe_int(row.get("conversation_failures"))
+        judge_errors = _safe_int(row.get("records_with_errors"))
+        if not (conv_failures or judge_errors) or not total:
+            continue
+        metric_errors = row.get("metrics_with_errors") or {}
+        if not isinstance(metric_errors, dict):
+            metric_errors = {}
+        metric_breakdown = ", ".join(f"{m} ({n})" for m, n in sorted(metric_errors.items())) or "—"
+        error_rows.append(
+            {
+                "System": row["system_name"],
+                "Timestamp": row["run_timestamp"],
+                "# Records": total,
+                "Conversation Failures": conv_failures,
+                "Judge Errors": judge_errors,
+                "Judge Error Rate": judge_errors / total,
+                "Metrics with Errors": metric_breakdown,
+            }
+        )
+    if error_rows:
+        st.markdown("#### Errors")
+        st.caption(
+            "**Conversation Failures**: records where conversation generation failed. "
+            "**Judge Errors**: records where one or more metrics failed to compute."
+        )
+        errors_df = pd.DataFrame(error_rows)
+        errors_styled = errors_df.style.format({"Judge Error Rate": "{:.1%}"})
+        st.dataframe(errors_styled, hide_index=True)
 
     csv = summary_df.drop(columns=["label"]).to_csv(index=False)
     st.download_button("Download CSV", csv, file_name="cross_run_comparison.csv", mime="text/csv")
@@ -1331,6 +1399,44 @@ def render_run_overview(run_dir: Path):
             st.plotly_chart(fig)
 
     st.divider()
+
+    # --- Errors ---
+    metrics_summary = _load_metrics_summary(run_dir)
+    data_quality = (metrics_summary or {}).get("data_quality") or {}
+    eval_summary = _load_evaluation_summary(run_dir)
+    simulation = eval_summary.get("simulation") or {}
+    judge_errors = data_quality.get("records_with_errors") or 0
+    conv_failures = simulation.get("failed_records") or 0
+    total_records = (
+        data_quality.get("total_records")
+        or (metrics_summary or {}).get("total_records")
+        or simulation.get("total_records")
+    )
+    metric_errors = data_quality.get("metrics_with_errors") or {}
+    if (judge_errors or conv_failures) and total_records:
+        st.markdown("### Errors")
+        summary_parts = []
+        if conv_failures:
+            summary_parts.append(f"**{conv_failures}** conversation failures ({conv_failures / total_records:.1%})")
+        if judge_errors:
+            summary_parts.append(f"**{judge_errors}** records with judge errors ({judge_errors / total_records:.1%})")
+        st.caption(f"Out of {total_records} records — " + " · ".join(summary_parts))
+        if metric_errors:
+            metric_error_df = pd.DataFrame(
+                [
+                    {
+                        "Metric": _format_metric_name(m),
+                        "# Errors": int(n),
+                        "Error Rate": int(n) / total_records,
+                    }
+                    for m, n in sorted(metric_errors.items(), key=lambda kv: kv[1], reverse=True)
+                ]
+            )
+            st.dataframe(
+                metric_error_df.style.format({"Error Rate": "{:.1%}"}),
+                hide_index=True,
+            )
+        st.divider()
 
     # --- Per-record table ---
     st.markdown("### Per-Record Metrics")

--- a/apps/analysis.py
+++ b/apps/analysis.py
@@ -79,6 +79,30 @@ _CATEGORY_COLORS = {
 
 _NON_NORMALIZED_METRICS = {"response_speed"}
 
+# Prefix shown in front of metric labels when the metric is lower-is-better.
+_LOWER_IS_BETTER_PREFIX = "↓ "
+
+
+def _is_lower_is_better(name: str) -> bool:
+    """Return True if a metric or sub-metric reads lower-is-better.
+
+    Parent metric direction comes from the metric class (via the registry).
+    Sub-metric direction is derived from the key suffix: ``_rate`` → lower is
+    better, ``_accuracy`` → higher is better, otherwise inherit the parent.
+    Sub-metric keys are encoded as ``<parent>__<sub_key>`` in the analysis app.
+    """
+    parent, _, sub_key = name.partition("__")
+    metric_class = get_global_registry().get(parent)
+    parent_higher_is_better = True if metric_class is None else metric_class.higher_is_better
+    if not sub_key:
+        return not parent_higher_is_better
+    if sub_key.endswith("_rate"):
+        return True
+    if sub_key.endswith("_accuracy"):
+        return False
+    return not parent_higher_is_better
+
+
 # EVA composite scores to show in the bar chart
 _EVA_BAR_COMPOSITES = ["EVA-A_pass", "EVA-X_pass", "EVA-A_mean", "EVA-X_mean"]
 
@@ -248,15 +272,21 @@ def _sort_metrics_by_category(metric_names: list[str]) -> list[str]:
     return sorted(metric_names, key=_sort_key)
 
 
+def _direction_prefix(name: str) -> str:
+    """Return the lower-is-better prefix (e.g. ``"↓ "``) if applicable, else ``""``."""
+    return _LOWER_IS_BETTER_PREFIX if _is_lower_is_better(name) else ""
+
+
 def _make_category_header_rename(metric_names: list[str]) -> dict[str, str]:
     """Prefix metric names with their category for display."""
-    return {m: f"[{_METRIC_GROUP.get(m, 'Other')}] {m}" for m in metric_names}
+    return {m: f"[{_METRIC_GROUP.get(m, 'Other')}] {_direction_prefix(m)}{m}" for m in metric_names}
 
 
 def _format_metric_name(name: str) -> str:
     """Format a metric name for display, preserving acronyms."""
     parts = name.split("_")
-    return " ".join(p.upper() if p.lower() in _ACRONYMS else p.capitalize() for p in parts)
+    formatted = " ".join(p.upper() if p.lower() in _ACRONYMS else p.capitalize() for p in parts)
+    return f"{_direction_prefix(name)}{formatted}"
 
 
 def _score_color(score: float | None) -> str:
@@ -1183,6 +1213,7 @@ def render_run_overview(run_dir: Path):
         chart_rows = [
             {
                 "metric": _format_metric_name(m),
+                "raw_metric": m,
                 "mean": stats["mean"],
                 "std": stats["std"],
                 "min": stats["min"],
@@ -1196,10 +1227,12 @@ def render_run_overview(run_dir: Path):
         if chart_rows:
             chart_df = pd.DataFrame(chart_rows)
 
-            # Sort by category order then metric name within category
+            # Sort by category order, then raw metric name so sub-metrics stay next to their parent.
             cat_order = {c: i for i, c in enumerate(_CATEGORY_ORDER + ["Other"])}
             chart_df["_cat_sort"] = chart_df["category"].map(lambda c: cat_order.get(c, len(cat_order)))
-            chart_df = chart_df.sort_values(["_cat_sort", "metric"], ascending=[True, True]).drop(columns=["_cat_sort"])
+            chart_df = chart_df.sort_values(["_cat_sort", "raw_metric"], ascending=[True, True]).drop(
+                columns=["_cat_sort", "raw_metric"]
+            )
 
             fig = go.Figure()
             for cat in _CATEGORY_ORDER + ["Other"]:
@@ -1897,7 +1930,7 @@ def _get_run_dirs():
     if latest_only:
         run_dirs = filter_latest_runs(run_dirs)
 
-    st.sidebar.toggle("Show sub-metrics", value=False, key="show_sub_metrics")
+    st.sidebar.toggle("Show sub-metrics", value=False, key="show_sub_metrics", bind="query-params")
 
     if not run_dirs:
         st.error(f"No run directories found in: {', '.join(str(d) for d in output_dirs)}")

--- a/src/eva/metrics/accuracy/faithfulness.py
+++ b/src/eva/metrics/accuracy/faithfulness.py
@@ -5,7 +5,16 @@ from typing import Any
 
 from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
 from eva.metrics.registry import register_metric
+from eva.metrics.utils import build_dimension_sub_metrics
 from eva.models.results import MetricScore
+
+_FAITHFULNESS_DIMENSION_KEYS = (
+    "fabricating_tool_parameters",
+    "misrepresenting_tool_result",
+    "violating_policies",
+    "failing_to_disambiguate",
+    "hallucination",
+)
 
 # --- Pipeline-specific prompt text for faithfulness evaluation ---
 
@@ -94,14 +103,18 @@ class FaithfulnessJudgeMetric(ConversationTextJudgeMetric):
         context: MetricContext,
         raw_response: str | None = None,
     ) -> MetricScore:
-        """Build MetricScore with analysis details."""
-        analysis = {
-            "dimensions": response.get("dimensions", {}),
-        }
+        """Build MetricScore with analysis details and per-dimension sub-metrics."""
+        dimensions = response.get("dimensions", {}) or {}
+        sub_metrics = build_dimension_sub_metrics(
+            self.name, dimensions, _FAITHFULNESS_DIMENSION_KEYS, self.rating_scale
+        )
+
+        analysis = {"dimensions": dimensions}
         return MetricScore(
             name=self.name,
             score=float(rating),
             normalized_score=normalized,
+            error=None,
             details={
                 "rating": rating,
                 "explanation": analysis,
@@ -109,4 +122,5 @@ class FaithfulnessJudgeMetric(ConversationTextJudgeMetric):
                 "judge_prompt": prompt,
                 "judge_raw_response": raw_response,
             },
+            sub_metrics=sub_metrics or None,
         )

--- a/src/eva/metrics/accuracy/faithfulness.py
+++ b/src/eva/metrics/accuracy/faithfulness.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
 from eva.metrics.registry import register_metric
-from eva.metrics.utils import build_dimension_sub_metrics
+from eva.metrics.utils import build_binary_flag_sub_metrics
 from eva.models.results import MetricScore
 
 _FAITHFULNESS_DIMENSION_KEYS = (
@@ -103,10 +103,14 @@ class FaithfulnessJudgeMetric(ConversationTextJudgeMetric):
         context: MetricContext,
         raw_response: str | None = None,
     ) -> MetricScore:
-        """Build MetricScore with analysis details and per-dimension sub-metrics."""
+        """Build MetricScore with analysis details and per-dimension issue-flag sub-metrics."""
         dimensions = response.get("dimensions", {}) or {}
-        sub_metrics = build_dimension_sub_metrics(
-            self.name, dimensions, _FAITHFULNESS_DIMENSION_KEYS, self.rating_scale
+        sub_metrics = build_binary_flag_sub_metrics(
+            parent_name=self.name,
+            entries=dimensions,
+            entry_keys=_FAITHFULNESS_DIMENSION_KEYS,
+            flag_field="flagged",
+            detail_fields=("rating", "evidence"),
         )
 
         analysis = {"dimensions": dimensions}

--- a/src/eva/metrics/accuracy/faithfulness.py
+++ b/src/eva/metrics/accuracy/faithfulness.py
@@ -118,7 +118,6 @@ class FaithfulnessJudgeMetric(ConversationTextJudgeMetric):
             name=self.name,
             score=float(rating),
             normalized_score=normalized,
-            error=None,
             details={
                 "rating": rating,
                 "explanation": analysis,

--- a/src/eva/metrics/base.py
+++ b/src/eva/metrics/base.py
@@ -383,6 +383,19 @@ class PerTurnConversationJudgeMetric(TextJudgeMetric):
         """
         return {}
 
+    def build_sub_metrics(
+        self,
+        context: MetricContext,
+        per_turn_ratings: dict[int, int | None],
+        per_turn_extra: dict[int, dict[str, Any]],
+    ) -> dict[str, MetricScore] | None:
+        """Return sub-metrics derived from the per-turn data, or None.
+
+        Override in subclasses to surface breakdowns (e.g., per-failure-mode rates).
+        Default returns None so the parent metric has no sub-metrics.
+        """
+        return None
+
     async def compute(self, context: MetricContext) -> MetricScore:
         """Evaluate all turns in a single judge call and aggregate per-turn ratings."""
         try:
@@ -480,11 +493,14 @@ class PerTurnConversationJudgeMetric(TextJudgeMetric):
                     tid: normalize_rating(r, min_r, max_r) for tid, r in per_turn_ratings.items() if r is not None
                 }
 
+            sub_metrics = self.build_sub_metrics(context, per_turn_ratings, per_turn_extra)
+
             return MetricScore(
                 name=self.name,
                 score=round(mean_rating, 3),
                 normalized_score=round(normalized_score, 3),
                 details=details,
+                sub_metrics=sub_metrics or None,
             )
 
         except Exception as e:

--- a/src/eva/metrics/base.py
+++ b/src/eva/metrics/base.py
@@ -160,6 +160,10 @@ class BaseMetric(ABC):
     pass_at_k_threshold: float = 0.5  # Normalized score threshold for pass@k pass/fail
     exclude_from_pass_at_k: bool = False  # Set True for metrics not suitable for pass@k
     supported_pipeline_types: frozenset[PipelineType] = frozenset(PipelineType)  # Pipeline types this metric supports
+    # Direction of the displayed value (normalized_score if present, else score).
+    # Override to False for lower-is-better parent metrics (e.g. latency). Sub-metric
+    # direction is derived from the key suffix (see eva.metrics.utils.direction_for_sub_metric).
+    higher_is_better: bool = True
 
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize the metric.

--- a/src/eva/metrics/diagnostic/response_speed.py
+++ b/src/eva/metrics/diagnostic/response_speed.py
@@ -68,6 +68,7 @@ class ResponseSpeedMetric(CodeMetric):
                     score=0.0,
                     normalized_score=None,
                     error="No response latencies available (missing audio timestamps)",
+                    higher_is_better=False,
                 )
 
             all_latencies = list(context.latency_assistant_turns.values())
@@ -79,6 +80,7 @@ class ResponseSpeedMetric(CodeMetric):
                     score=0.0,
                     normalized_score=None,
                     error="No valid response speeds computed",
+                    higher_is_better=False,
                 )
 
             dropped = [v for v in all_latencies if not (0 < v < 1000)]
@@ -98,6 +100,7 @@ class ResponseSpeedMetric(CodeMetric):
                         score=stats["mean_speed_seconds"],
                         normalized_score=None,
                         details=stats,
+                        higher_is_better=False,
                     )
 
             return MetricScore(
@@ -106,6 +109,7 @@ class ResponseSpeedMetric(CodeMetric):
                 normalized_score=None,
                 details=overall_stats,
                 sub_metrics=sub_metrics or None,
+                higher_is_better=False,
             )
 
         except Exception as e:

--- a/src/eva/metrics/diagnostic/response_speed.py
+++ b/src/eva/metrics/diagnostic/response_speed.py
@@ -59,6 +59,7 @@ class ResponseSpeedMetric(CodeMetric):
     category = "diagnostic"
     description = "Diagnostic metric: latency between user utterance end and assistant response start"
     exclude_from_pass_at_k = True
+    higher_is_better = False  # Score is latency in seconds — lower is better.
 
     async def compute(self, context: MetricContext) -> MetricScore:
         try:
@@ -68,7 +69,6 @@ class ResponseSpeedMetric(CodeMetric):
                     score=0.0,
                     normalized_score=None,
                     error="No response latencies available (missing audio timestamps)",
-                    higher_is_better=False,
                 )
 
             all_latencies = list(context.latency_assistant_turns.values())
@@ -80,7 +80,6 @@ class ResponseSpeedMetric(CodeMetric):
                     score=0.0,
                     normalized_score=None,
                     error="No valid response speeds computed",
-                    higher_is_better=False,
                 )
 
             dropped = [v for v in all_latencies if not (0 < v < 1000)]
@@ -100,7 +99,6 @@ class ResponseSpeedMetric(CodeMetric):
                         score=stats["mean_speed_seconds"],
                         normalized_score=None,
                         details=stats,
-                        higher_is_better=False,
                     )
 
             return MetricScore(
@@ -109,7 +107,6 @@ class ResponseSpeedMetric(CodeMetric):
                 normalized_score=None,
                 details=overall_stats,
                 sub_metrics=sub_metrics or None,
-                higher_is_better=False,
             )
 
         except Exception as e:

--- a/src/eva/metrics/diagnostic/stt_wer.py
+++ b/src/eva/metrics/diagnostic/stt_wer.py
@@ -10,12 +10,44 @@ import jiwer
 
 from eva.metrics.base import CodeMetric, MetricContext
 from eva.metrics.registry import register_metric
-from eva.metrics.utils import aggregate_wer_errors, extract_wer_errors, reverse_word_error_rate
+from eva.metrics.utils import aggregate_wer_errors, extract_wer_errors, make_rate_sub_metric, reverse_word_error_rate
 from eva.models.config import PipelineType
 from eva.models.results import MetricScore
 from eva.utils.wer_normalization import normalize_text
 
 _BRACKET_PATTERN = re.compile(r"\[.*?\]")
+
+
+def _build_wer_component_sub_metrics(
+    parent_name: str,
+    substitutions: int,
+    deletions: int,
+    insertions: int,
+    reference_words: int,
+) -> dict[str, MetricScore]:
+    """Build sub-metrics for substitution, deletion, and insertion rates.
+
+    Each rate = component count / reference word count. Returns an empty dict
+    when there are no reference words (division by zero).
+    """
+    if reference_words <= 0:
+        return {}
+
+    components = {
+        "substitution_rate": substitutions,
+        "deletion_rate": deletions,
+        "insertion_rate": insertions,
+    }
+    return {
+        key: make_rate_sub_metric(
+            parent_name=parent_name,
+            key=key,
+            numerator=count,
+            denominator=reference_words,
+            details={"count": count, "reference_words": reference_words},
+        )
+        for key, count in components.items()
+    }
 
 
 @register_metric
@@ -104,6 +136,15 @@ class STTWERMetric(CodeMetric):
             # Aggregate error statistics across all turns
             error_summary = aggregate_wer_errors(output)
 
+            reference_word_count = sum(len(r.split()) for r in references_clean)
+            sub_metrics = _build_wer_component_sub_metrics(
+                parent_name=self.name,
+                substitutions=output.substitutions,
+                deletions=output.deletions,
+                insertions=output.insertions,
+                reference_words=reference_word_count,
+            )
+
             return MetricScore(
                 name=self.name,
                 score=round(wer, 3),  # Raw WER
@@ -120,7 +161,9 @@ class STTWERMetric(CodeMetric):
                     "total_substitutions": output.substitutions,
                     "total_deletions": output.deletions,
                     "total_insertions": output.insertions,
+                    "reference_words": reference_word_count,
                 },
+                sub_metrics=sub_metrics or None,
             )
 
         except Exception as e:

--- a/src/eva/metrics/diagnostic/tool_call_validity.py
+++ b/src/eva/metrics/diagnostic/tool_call_validity.py
@@ -11,6 +11,7 @@ final evaluation scores.
 from eva.assistant.tools.airline_params import FIELD_ERROR_TYPES
 from eva.metrics.base import CodeMetric, MetricContext
 from eva.metrics.registry import register_metric
+from eva.metrics.utils import make_rate_sub_metric
 from eva.models.results import MetricScore
 
 # Infrastructure errors from ToolExecutor + generic Pydantic fallback.
@@ -49,6 +50,14 @@ class ToolCallValidity(CodeMetric):
                 score=1.0,
                 normalized_score=1.0,
                 details={"total_tool_calls": 0, "note": "No tool calls to evaluate"},
+                sub_metrics={
+                    "num_tool_calls": MetricScore(
+                        name=f"{self.name}.num_tool_calls",
+                        score=0.0,
+                        normalized_score=None,
+                        details={},
+                    )
+                },
             )
 
         format_errors = []
@@ -73,6 +82,8 @@ class ToolCallValidity(CodeMetric):
         correct = total - len(format_errors)
         score = correct / total
 
+        sub_metrics = _build_tool_call_validity_sub_metrics(self.name, total, format_errors)
+
         return MetricScore(
             name=self.name,
             score=round(score, 4),
@@ -83,4 +94,46 @@ class ToolCallValidity(CodeMetric):
                 "invalid_tool_calls": len(format_errors),
                 "errors": format_errors,
             },
+            sub_metrics=sub_metrics or None,
         )
+
+
+def _build_tool_call_validity_sub_metrics(
+    parent_name: str,
+    total_tool_calls: int,
+    format_errors: list[dict],
+) -> dict[str, MetricScore]:
+    """Build sub-metrics for total tool call count and per-error-type rates.
+
+    ``num_tool_calls`` is a count (normalized_score=None). Per-error-type rates
+    are emitted for every known error type so keys are stable across records.
+    """
+    sub_metrics: dict[str, MetricScore] = {
+        "num_tool_calls": MetricScore(
+            name=f"{parent_name}.num_tool_calls",
+            score=float(total_tool_calls),
+            normalized_score=None,
+            details={},
+        )
+    }
+
+    if total_tool_calls == 0:
+        return sub_metrics
+
+    error_counts: dict[str, int] = dict.fromkeys(CALL_ERROR_TYPES, 0)
+    for error in format_errors:
+        error_type = error.get("error_type")
+        if error_type in error_counts:
+            error_counts[error_type] += 1
+
+    for error_type, count in error_counts.items():
+        sub_metrics[f"{error_type}_rate"] = make_rate_sub_metric(
+            parent_name=parent_name,
+            key=f"{error_type}_rate",
+            numerator=count,
+            denominator=total_tool_calls,
+            details={"count": count, "total_tool_calls": total_tool_calls},
+            precision=4,
+        )
+
+    return sub_metrics

--- a/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
+++ b/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
@@ -8,7 +8,12 @@ from typing import Any
 
 from eva.metrics.base import MetricContext, TextJudgeMetric
 from eva.metrics.registry import register_metric
-from eva.metrics.utils import aggregate_per_turn_scores, parse_judge_response_list, resolve_turn_id
+from eva.metrics.utils import (
+    aggregate_per_turn_scores,
+    make_rate_sub_metric,
+    parse_judge_response_list,
+    resolve_turn_id,
+)
 from eva.models.config import PipelineType
 from eva.models.results import MetricScore
 
@@ -126,6 +131,8 @@ class TranscriptionAccuracyKeyEntitiesMetric(TextJudgeMetric):
             # (judge responded for all of them — -1 means no entities, not a failure)
             num_evaluated = len(valid_ratings) + len(not_applicable)
 
+            sub_metrics = self._build_per_entity_type_sub_metrics(per_turn_entity_details)
+
             return MetricScore(
                 name=self.name,
                 score=round(avg_rating, 3) if avg_rating is not None else None,
@@ -143,11 +150,58 @@ class TranscriptionAccuracyKeyEntitiesMetric(TextJudgeMetric):
                     "per_turn_entity_details": per_turn_entity_details,
                     "judge_raw_response": response_text,
                 },
+                sub_metrics=sub_metrics or None,
                 skipped=skipped,
             )
 
         except Exception as e:
             return self._handle_error(e, context)
+
+    def _build_per_entity_type_sub_metrics(
+        self,
+        per_turn_entity_details: dict[int, dict],
+    ) -> dict[str, MetricScore]:
+        """Aggregate entities by ``type`` across turns and build one sub-metric per type.
+
+        For each type: score = correct / non-skipped count across all turns.
+        Types with zero non-skipped entities are omitted.
+        """
+        per_type_correct: dict[str, int] = {}
+        per_type_non_skipped: dict[str, int] = {}
+        per_type_skipped: dict[str, int] = {}
+
+        for turn_eval in per_turn_entity_details.values():
+            entities = turn_eval.get("entities", []) if isinstance(turn_eval, dict) else []
+            for entity in entities:
+                if not isinstance(entity, dict):
+                    continue
+                entity_type = entity.get("type")
+                if not isinstance(entity_type, str) or not entity_type:
+                    continue
+                if entity.get("skipped", False):
+                    per_type_skipped[entity_type] = per_type_skipped.get(entity_type, 0) + 1
+                    continue
+                per_type_non_skipped[entity_type] = per_type_non_skipped.get(entity_type, 0) + 1
+                if entity.get("correct", False):
+                    per_type_correct[entity_type] = per_type_correct.get(entity_type, 0) + 1
+
+        sub_metrics: dict[str, MetricScore] = {}
+        for entity_type, non_skipped in per_type_non_skipped.items():
+            if non_skipped == 0:
+                continue
+            correct = per_type_correct.get(entity_type, 0)
+            sub_metrics[entity_type] = make_rate_sub_metric(
+                parent_name=self.name,
+                key=entity_type,
+                numerator=correct,
+                denominator=non_skipped,
+                details={
+                    "correct": correct,
+                    "total_non_skipped": non_skipped,
+                    "skipped": per_type_skipped.get(entity_type, 0),
+                },
+            )
+        return sub_metrics
 
     @staticmethod
     def _get_turns_to_evaluate(context: MetricContext) -> list[int]:

--- a/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
+++ b/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
@@ -190,7 +190,7 @@ class TranscriptionAccuracyKeyEntitiesMetric(TextJudgeMetric):
             if non_skipped == 0:
                 continue
             correct = per_type_correct.get(entity_type, 0)
-            # Per-type score is accuracy (correct / non-skipped), so higher is better.
+            # Key suffix ``_accuracy`` signals higher-is-better at read time.
             sub_key = f"{entity_type}_accuracy"
             sub_metrics[sub_key] = make_rate_sub_metric(
                 parent_name=self.name,
@@ -202,7 +202,6 @@ class TranscriptionAccuracyKeyEntitiesMetric(TextJudgeMetric):
                     "total_non_skipped": non_skipped,
                     "skipped": per_type_skipped.get(entity_type, 0),
                 },
-                higher_is_better=True,
             )
         return sub_metrics
 

--- a/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
+++ b/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
@@ -190,9 +190,11 @@ class TranscriptionAccuracyKeyEntitiesMetric(TextJudgeMetric):
             if non_skipped == 0:
                 continue
             correct = per_type_correct.get(entity_type, 0)
-            sub_metrics[entity_type] = make_rate_sub_metric(
+            # Per-type score is accuracy (correct / non-skipped), so higher is better.
+            sub_key = f"{entity_type}_accuracy"
+            sub_metrics[sub_key] = make_rate_sub_metric(
                 parent_name=self.name,
-                key=entity_type,
+                key=sub_key,
                 numerator=correct,
                 denominator=non_skipped,
                 details={
@@ -200,6 +202,7 @@ class TranscriptionAccuracyKeyEntitiesMetric(TextJudgeMetric):
                     "total_non_skipped": non_skipped,
                     "skipped": per_type_skipped.get(entity_type, 0),
                 },
+                higher_is_better=True,
             )
         return sub_metrics
 

--- a/src/eva/metrics/experience/conciseness.py
+++ b/src/eva/metrics/experience/conciseness.py
@@ -4,6 +4,15 @@ from typing import Any
 
 from eva.metrics.base import MetricContext, PerTurnConversationJudgeMetric
 from eva.metrics.registry import register_metric
+from eva.metrics.utils import make_rate_sub_metric
+from eva.models.results import MetricScore
+
+_CONCISENESS_FAILURE_MODES = (
+    "verbosity_or_filler",
+    "excess_information_density",
+    "over_enumeration_or_list_exhaustion",
+    "contextually_disproportionate_detail",
+)
 
 
 @register_metric
@@ -51,3 +60,29 @@ class ConcisenessJudgeMetric(PerTurnConversationJudgeMetric):
             failure_modes = []
 
         return {"failure_modes": failure_modes}
+
+    def build_sub_metrics(
+        self,
+        context: MetricContext,
+        per_turn_ratings: dict[int, int | None],
+        per_turn_extra: dict[int, dict[str, Any]],
+    ) -> dict[str, MetricScore] | None:
+        """Surface one sub-metric per failure mode, rate = flagged turns / rated turns."""
+        rated_turn_ids = [tid for tid, r in per_turn_ratings.items() if r is not None]
+        num_rated = len(rated_turn_ids)
+        if num_rated == 0:
+            return None
+
+        sub_metrics: dict[str, MetricScore] = {}
+        for mode in _CONCISENESS_FAILURE_MODES:
+            flagged_ids = [
+                tid for tid in rated_turn_ids if mode in (per_turn_extra.get(tid, {}).get("failure_modes") or [])
+            ]
+            sub_metrics[mode] = make_rate_sub_metric(
+                parent_name=self.name,
+                key=mode,
+                numerator=len(flagged_ids),
+                denominator=num_rated,
+                details={"count": len(flagged_ids), "num_rated": num_rated, "turn_ids": flagged_ids},
+            )
+        return sub_metrics

--- a/src/eva/metrics/experience/conciseness.py
+++ b/src/eva/metrics/experience/conciseness.py
@@ -78,9 +78,10 @@ class ConcisenessJudgeMetric(PerTurnConversationJudgeMetric):
             flagged_ids = [
                 tid for tid in rated_turn_ids if mode in (per_turn_extra.get(tid, {}).get("failure_modes") or [])
             ]
-            sub_metrics[mode] = make_rate_sub_metric(
+            sub_key = f"{mode}_rate"
+            sub_metrics[sub_key] = make_rate_sub_metric(
                 parent_name=self.name,
-                key=mode,
+                key=sub_key,
                 numerator=len(flagged_ids),
                 denominator=num_rated,
                 details={"count": len(flagged_ids), "num_rated": num_rated, "turn_ids": flagged_ids},

--- a/src/eva/metrics/experience/conversation_progression.py
+++ b/src/eva/metrics/experience/conversation_progression.py
@@ -4,7 +4,15 @@ from typing import Any
 
 from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
 from eva.metrics.registry import register_metric
+from eva.metrics.utils import build_dimension_sub_metrics
 from eva.models.results import MetricScore
+
+_CONVERSATION_PROGRESSION_DIMENSION_KEYS = (
+    "unnecessary_tool_calls",
+    "information_loss",
+    "redundant_statements",
+    "question_quality",
+)
 
 
 @register_metric
@@ -36,15 +44,21 @@ class ConversationProgressionJudgeMetric(ConversationTextJudgeMetric):
         context: MetricContext,
         raw_response: str | None = None,
     ) -> MetricScore:
-        """Build MetricScore with analysis details."""
+        """Build MetricScore with analysis details and per-dimension sub-metrics."""
+        dimensions = response.get("dimensions", {}) or {}
+        sub_metrics = build_dimension_sub_metrics(
+            self.name, dimensions, _CONVERSATION_PROGRESSION_DIMENSION_KEYS, self.rating_scale
+        )
+
         analysis = {
-            "dimensions": response.get("dimensions", {}),
+            "dimensions": dimensions,
             "flags_count": response.get("flags_count", ""),
         }
         return MetricScore(
             name=self.name,
             score=float(rating),
             normalized_score=normalized,
+            error=None,
             details={
                 "rating": rating,
                 "explanation": analysis,
@@ -52,4 +66,5 @@ class ConversationProgressionJudgeMetric(ConversationTextJudgeMetric):
                 "judge_prompt": prompt,
                 "judge_raw_response": raw_response,
             },
+            sub_metrics=sub_metrics or None,
         )

--- a/src/eva/metrics/experience/conversation_progression.py
+++ b/src/eva/metrics/experience/conversation_progression.py
@@ -62,7 +62,6 @@ class ConversationProgressionJudgeMetric(ConversationTextJudgeMetric):
             name=self.name,
             score=float(rating),
             normalized_score=normalized,
-            error=None,
             details={
                 "rating": rating,
                 "explanation": analysis,

--- a/src/eva/metrics/experience/conversation_progression.py
+++ b/src/eva/metrics/experience/conversation_progression.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
 from eva.metrics.registry import register_metric
-from eva.metrics.utils import build_dimension_sub_metrics
+from eva.metrics.utils import build_binary_flag_sub_metrics
 from eva.models.results import MetricScore
 
 _CONVERSATION_PROGRESSION_DIMENSION_KEYS = (
@@ -44,10 +44,14 @@ class ConversationProgressionJudgeMetric(ConversationTextJudgeMetric):
         context: MetricContext,
         raw_response: str | None = None,
     ) -> MetricScore:
-        """Build MetricScore with analysis details and per-dimension sub-metrics."""
+        """Build MetricScore with analysis details and per-dimension issue-flag sub-metrics."""
         dimensions = response.get("dimensions", {}) or {}
-        sub_metrics = build_dimension_sub_metrics(
-            self.name, dimensions, _CONVERSATION_PROGRESSION_DIMENSION_KEYS, self.rating_scale
+        sub_metrics = build_binary_flag_sub_metrics(
+            parent_name=self.name,
+            entries=dimensions,
+            entry_keys=_CONVERSATION_PROGRESSION_DIMENSION_KEYS,
+            flag_field="flagged",
+            detail_fields=("rating", "evidence"),
         )
 
         analysis = {

--- a/src/eva/metrics/runner.py
+++ b/src/eva/metrics/runner.py
@@ -14,6 +14,7 @@ from eva.metrics.aggregation import compute_record_aggregates, compute_run_level
 from eva.metrics.base import BaseMetric, MetricContext
 from eva.metrics.processor import MetricsContextProcessor
 from eva.metrics.registry import MetricRegistry, get_global_registry
+from eva.metrics.utils import direction_for_sub_metric
 from eva.models.config import PipelineType, get_pipeline_type
 from eva.models.record import EvaluationRecord
 from eva.models.results import ConversationResult, MetricScore, PassAtKResult, RecordMetrics
@@ -28,6 +29,16 @@ from eva.utils.pass_at_k import (
 from eva.utils.provenance import capture_metrics_provenance
 
 logger = get_logger(__name__)
+
+
+def _metric_higher_is_better(name: str) -> bool:
+    """Return ``higher_is_better`` for a registered metric, or ``True`` if unknown.
+
+    Direction lives on the metric class (static per metric), so the aggregator
+    reads it from the registry rather than fishing it out of per-record data.
+    """
+    metric_class = get_global_registry().get(name)
+    return True if metric_class is None else metric_class.higher_is_better
 
 
 @dataclass
@@ -605,6 +616,7 @@ class MetricsRunner:
                         coverage["not_applicable_turns"] = total_not_applicable_across_records
                     entry["per_turn_coverage"] = coverage
 
+                entry["higher_is_better"] = _metric_higher_is_better(name)
                 metric_aggregates[name] = entry
 
         # Add pass_k aggregates if available
@@ -646,6 +658,7 @@ class MetricsRunner:
             if not all_sub_keys:
                 continue
 
+            parent_direction = _metric_higher_is_better(name)
             sub_aggs: dict[str, dict[str, Any]] = {}
             for sub_key in sorted(all_sub_keys):
                 sub_scores: list[float] = []
@@ -656,15 +669,15 @@ class MetricsRunner:
                         sub_missing += 1
                         continue
                     sub_ms = (ms.sub_metrics or {}).get(sub_key)
-                    if sub_ms is not None and sub_ms.score is not None:
-                        sub_scores.append(
-                            sub_ms.normalized_score if sub_ms.normalized_score is not None else sub_ms.score
-                        )
-                    else:
+                    if sub_ms is None or sub_ms.score is None:
                         sub_missing += 1
+                        continue
+                    sub_scores.append(sub_ms.normalized_score if sub_ms.normalized_score is not None else sub_ms.score)
 
                 if sub_scores or sub_missing > 0:
-                    sub_aggs[sub_key] = MetricsRunner._aggregate_scores(sub_scores, total_records, 0, sub_missing)
+                    sub_entry = MetricsRunner._aggregate_scores(sub_scores, total_records, 0, sub_missing)
+                    sub_entry["higher_is_better"] = direction_for_sub_metric(sub_key, parent_direction)
+                    sub_aggs[sub_key] = sub_entry
 
             if sub_aggs:
                 metric_aggregates[name]["sub_metrics"] = sub_aggs

--- a/src/eva/metrics/utils.py
+++ b/src/eva/metrics/utils.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from pydub import AudioSegment
 
+from eva.models.results import MetricScore
 from eva.utils.json_utils import extract_and_load_json
 from eva.utils.logging import get_logger
 
@@ -322,6 +323,87 @@ def compute_aggregation(aggregation: str, scores: list[int | float | None]) -> f
 def reverse_word_error_rate(wer: float) -> float:
     """Convert WER to accuracy."""
     return 1 - min(1.0, wer)
+
+
+def make_rate_sub_metric(
+    parent_name: str,
+    key: str,
+    numerator: int,
+    denominator: int,
+    details: dict[str, Any],
+    precision: int = 3,
+) -> MetricScore:
+    """Build a rate-style sub-metric where ``score == normalized_score == numerator/denominator``.
+
+    Returns a zero-rate sub-metric when ``denominator <= 0`` so callers never
+    divide by zero. Callers are responsible for choosing the ``details`` shape
+    (counts, turn IDs, reference counts, etc.) that makes sense for their metric.
+
+    Args:
+        parent_name: Parent metric's name (used as prefix in sub-metric name).
+        key: Sub-metric key suffix (final name is ``f"{parent_name}.{key}"``).
+        numerator: Count (e.g., flagged turns, component errors, correct entities).
+        denominator: Denominator (e.g., rated turns, reference words, total calls).
+        details: Details dict attached to the sub-metric.
+        precision: Number of decimal places to round the rate to.
+
+    Returns:
+        A MetricScore with equal ``score`` and ``normalized_score`` fields.
+    """
+    rate = numerator / denominator if denominator > 0 else 0.0
+    rounded = round(rate, precision)
+    return MetricScore(
+        name=f"{parent_name}.{key}",
+        score=rounded,
+        normalized_score=rounded,
+        details=details,
+    )
+
+
+def build_dimension_sub_metrics(
+    parent_name: str,
+    dimensions: dict[str, Any],
+    dimension_keys: tuple[str, ...],
+    rating_scale: tuple[int, int],
+) -> dict[str, MetricScore]:
+    """Build sub-metrics for judge dimensions rated on a scale (e.g., 1-3).
+
+    Each dimension entry is expected to have at minimum a ``rating`` (int) and
+    optionally ``flagged`` (bool) and ``evidence`` (str). Only dimensions with
+    valid integer ratings in-range are surfaced.
+
+    Args:
+        parent_name: The parent metric's name (used as prefix in sub-metric name).
+        dimensions: Mapping of dimension key to its judge-response entry.
+        dimension_keys: Ordered tuple of expected dimension keys.
+        rating_scale: Tuple of (min, max) valid rating values.
+
+    Returns:
+        Dict keyed by dimension name with a MetricScore per surfaceable dimension.
+    """
+    min_r, max_r = rating_scale
+    valid_range = set(range(min_r, max_r + 1))
+    sub_metrics: dict[str, MetricScore] = {}
+
+    for dim_key in dimension_keys:
+        entry = dimensions.get(dim_key)
+        if not isinstance(entry, dict):
+            continue
+        rating = entry.get("rating")
+        if not isinstance(rating, int) or rating not in valid_range:
+            continue
+        sub_metrics[dim_key] = MetricScore(
+            name=f"{parent_name}.{dim_key}",
+            score=float(rating),
+            normalized_score=normalize_rating(rating, min_r, max_r),
+            details={
+                "rating": rating,
+                "flagged": entry.get("flagged"),
+                "evidence": entry.get("evidence", ""),
+            },
+        )
+
+    return sub_metrics
 
 
 def aggregate_per_turn_scores(scores: list[float | None], aggregation: str) -> float | None:

--- a/src/eva/metrics/utils.py
+++ b/src/eva/metrics/utils.py
@@ -332,17 +332,12 @@ def make_rate_sub_metric(
     denominator: int,
     details: dict[str, Any],
     precision: int = 3,
-    higher_is_better: bool = False,
 ) -> MetricScore:
     """Build a rate-style sub-metric where ``score == normalized_score == numerator/denominator``.
 
     Returns a zero-rate sub-metric when ``denominator <= 0`` so callers never
     divide by zero. Callers are responsible for choosing the ``details`` shape
     (counts, turn IDs, reference counts, etc.) that makes sense for their metric.
-
-    Defaults to ``higher_is_better=False`` because most rate sub-metrics measure
-    error/failure frequency (lower is better). Callers building accuracy-style
-    rates (e.g. per-entity-type accuracy, on-time rate) should pass ``True``.
 
     Args:
         parent_name: Parent metric's name (used as prefix in sub-metric name).
@@ -351,7 +346,6 @@ def make_rate_sub_metric(
         denominator: Denominator (e.g., rated turns, reference words, total calls).
         details: Details dict attached to the sub-metric.
         precision: Number of decimal places to round the rate to.
-        higher_is_better: Direction flag passed through to the MetricScore.
 
     Returns:
         A MetricScore with equal ``score`` and ``normalized_score`` fields.
@@ -363,8 +357,21 @@ def make_rate_sub_metric(
         score=rounded,
         normalized_score=rounded,
         details=details,
-        higher_is_better=higher_is_better,
     )
+
+
+def direction_for_sub_metric(sub_key: str, parent_higher_is_better: bool) -> bool:
+    """Derive a sub-metric's direction from its key suffix.
+
+    The convention: ``_rate`` suffix means lower-is-better (issue-frequency);
+    ``_accuracy`` suffix means higher-is-better; otherwise the sub-metric
+    inherits the parent metric's direction.
+    """
+    if sub_key.endswith("_rate"):
+        return False
+    if sub_key.endswith("_accuracy"):
+        return True
+    return parent_higher_is_better
 
 
 def build_binary_flag_sub_metrics(
@@ -380,11 +387,12 @@ def build_binary_flag_sub_metrics(
     Each entry is expected to carry a boolean flag under ``flag_field`` (e.g.,
     ``flagged`` or ``detected``) indicating whether the dimension was triggered
     for this record. Sub-metric convention: ``score = 1.0`` if the flag is true,
-    ``0.0`` otherwise. ``higher_is_better`` is set to ``False`` so aggregation
-    reads as "fraction of records where this issue occurred — lower is better".
+    ``0.0`` otherwise. Aggregated across records, the mean reads as "fraction of
+    records where this issue occurred".
 
     The default ``key_suffix`` of ``"_rate"`` reflects that these sub-metrics
-    aggregate across records into an issue-frequency rate.
+    aggregate into an issue-frequency rate — the suffix is what signals to the
+    reader (and to ``direction_for_sub_metric``) that lower is better.
 
     Args:
         parent_name: Parent metric name (prefix for the sub-metric name).
@@ -418,7 +426,6 @@ def build_binary_flag_sub_metrics(
             score=score,
             normalized_score=score,
             details=details,
-            higher_is_better=False,
         )
     return sub_metrics
 

--- a/src/eva/metrics/utils.py
+++ b/src/eva/metrics/utils.py
@@ -332,12 +332,17 @@ def make_rate_sub_metric(
     denominator: int,
     details: dict[str, Any],
     precision: int = 3,
+    higher_is_better: bool = False,
 ) -> MetricScore:
     """Build a rate-style sub-metric where ``score == normalized_score == numerator/denominator``.
 
     Returns a zero-rate sub-metric when ``denominator <= 0`` so callers never
     divide by zero. Callers are responsible for choosing the ``details`` shape
     (counts, turn IDs, reference counts, etc.) that makes sense for their metric.
+
+    Defaults to ``higher_is_better=False`` because most rate sub-metrics measure
+    error/failure frequency (lower is better). Callers building accuracy-style
+    rates (e.g. per-entity-type accuracy, on-time rate) should pass ``True``.
 
     Args:
         parent_name: Parent metric's name (used as prefix in sub-metric name).
@@ -346,6 +351,7 @@ def make_rate_sub_metric(
         denominator: Denominator (e.g., rated turns, reference words, total calls).
         details: Details dict attached to the sub-metric.
         precision: Number of decimal places to round the rate to.
+        higher_is_better: Direction flag passed through to the MetricScore.
 
     Returns:
         A MetricScore with equal ``score`` and ``normalized_score`` fields.
@@ -357,52 +363,63 @@ def make_rate_sub_metric(
         score=rounded,
         normalized_score=rounded,
         details=details,
+        higher_is_better=higher_is_better,
     )
 
 
-def build_dimension_sub_metrics(
+def build_binary_flag_sub_metrics(
     parent_name: str,
-    dimensions: dict[str, Any],
-    dimension_keys: tuple[str, ...],
-    rating_scale: tuple[int, int],
+    entries: dict[str, Any],
+    entry_keys: tuple[str, ...],
+    flag_field: str,
+    detail_fields: tuple[str, ...] = (),
+    key_suffix: str = "_rate",
 ) -> dict[str, MetricScore]:
-    """Build sub-metrics for judge dimensions rated on a scale (e.g., 1-3).
+    """Build binary "issue-occurrence" sub-metrics for a fixed set of judge dimensions.
 
-    Each dimension entry is expected to have at minimum a ``rating`` (int) and
-    optionally ``flagged`` (bool) and ``evidence`` (str). Only dimensions with
-    valid integer ratings in-range are surfaced.
+    Each entry is expected to carry a boolean flag under ``flag_field`` (e.g.,
+    ``flagged`` or ``detected``) indicating whether the dimension was triggered
+    for this record. Sub-metric convention: ``score = 1.0`` if the flag is true,
+    ``0.0`` otherwise. ``higher_is_better`` is set to ``False`` so aggregation
+    reads as "fraction of records where this issue occurred — lower is better".
+
+    The default ``key_suffix`` of ``"_rate"`` reflects that these sub-metrics
+    aggregate across records into an issue-frequency rate.
 
     Args:
-        parent_name: The parent metric's name (used as prefix in sub-metric name).
-        dimensions: Mapping of dimension key to its judge-response entry.
-        dimension_keys: Ordered tuple of expected dimension keys.
-        rating_scale: Tuple of (min, max) valid rating values.
+        parent_name: Parent metric name (prefix for the sub-metric name).
+        entries: Mapping of dimension key to its judge-response entry.
+        entry_keys: Ordered tuple of expected dimension keys.
+        flag_field: Name of the boolean field in each entry (e.g. ``"flagged"``,
+            ``"detected"``).
+        detail_fields: Additional fields from the entry to preserve in ``details``
+            (e.g. ``("rating", "evidence")`` or ``("analysis",)``).
+        key_suffix: Suffix appended to each dimension key in the returned dict
+            and in the sub-metric name (default ``"_rate"``).
 
     Returns:
-        Dict keyed by dimension name with a MetricScore per surfaceable dimension.
+        Dict keyed by ``f"{dimension_key}{key_suffix}"``. Entries whose
+        ``flag_field`` is missing or non-boolean are skipped.
     """
-    min_r, max_r = rating_scale
-    valid_range = set(range(min_r, max_r + 1))
     sub_metrics: dict[str, MetricScore] = {}
-
-    for dim_key in dimension_keys:
-        entry = dimensions.get(dim_key)
-        if not isinstance(entry, dict):
+    for key in entry_keys:
+        entry = entries.get(key)
+        if not isinstance(entry, dict) or flag_field not in entry:
             continue
-        rating = entry.get("rating")
-        if not isinstance(rating, int) or rating not in valid_range:
-            continue
-        sub_metrics[dim_key] = MetricScore(
-            name=f"{parent_name}.{dim_key}",
-            score=float(rating),
-            normalized_score=normalize_rating(rating, min_r, max_r),
-            details={
-                "rating": rating,
-                "flagged": entry.get("flagged"),
-                "evidence": entry.get("evidence", ""),
-            },
+        flagged = bool(entry.get(flag_field))
+        score = 1.0 if flagged else 0.0
+        details: dict[str, Any] = {flag_field: flagged}
+        for field in detail_fields:
+            if field in entry:
+                details[field] = entry[field]
+        sub_key = f"{key}{key_suffix}"
+        sub_metrics[sub_key] = MetricScore(
+            name=f"{parent_name}.{sub_key}",
+            score=score,
+            normalized_score=score,
+            details=details,
+            higher_is_better=False,
         )
-
     return sub_metrics
 
 

--- a/src/eva/metrics/validation/user_behavioral_fidelity.py
+++ b/src/eva/metrics/validation/user_behavioral_fidelity.py
@@ -7,6 +7,14 @@ from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
 from eva.metrics.registry import register_metric
 from eva.models.results import MetricScore
 
+_USER_BEHAVIORAL_FIDELITY_CORRUPTION_KEYS = (
+    "extra_modifications",
+    "premature_ending",
+    "missing_information",
+    "duplicate_modifications",
+    "decision_tree_violation",
+)
+
 # --- Pipeline-specific prompt text for user behavioral fidelity ---
 
 _CASCADE_CONVERSATION_EVIDENCE = (
@@ -85,16 +93,49 @@ class UserBehavioralFidelityMetric(ConversationTextJudgeMetric):
         context: MetricContext,
         raw_response: str | None = None,
     ) -> MetricScore:
-        """Build MetricScore with corruption analysis details."""
+        """Build MetricScore with corruption analysis details and per-type sub-metrics."""
+        corruption_analysis = response.get("corruption_analysis", {}) or {}
+        sub_metrics = _build_corruption_sub_metrics(self.name, corruption_analysis)
+
         return MetricScore(
             name=self.name,
             score=float(rating),
             normalized_score=normalized,
+            error=None,
             details={
                 "rating": rating,
                 "corrupted": rating == 0,
-                "corruption_analysis": response.get("corruption_analysis", {}),
+                "corruption_analysis": corruption_analysis,
                 "judge_prompt": prompt,
                 "judge_raw_response": raw_response,
             },
+            sub_metrics=sub_metrics or None,
         )
+
+
+def _build_corruption_sub_metrics(
+    parent_name: str,
+    corruption_analysis: dict[str, Any],
+) -> dict[str, MetricScore]:
+    """Build sub-metrics for each corruption type in the judge response.
+
+    Each corruption entry has ``detected`` (bool) and ``analysis`` (str).
+    Sub-metric convention: score = 1.0 if clean (not detected), 0.0 if detected.
+    """
+    sub_metrics: dict[str, MetricScore] = {}
+    for key in _USER_BEHAVIORAL_FIDELITY_CORRUPTION_KEYS:
+        entry = corruption_analysis.get(key)
+        if not isinstance(entry, dict) or "detected" not in entry:
+            continue
+        detected = bool(entry.get("detected"))
+        score = 0.0 if detected else 1.0
+        sub_metrics[key] = MetricScore(
+            name=f"{parent_name}.{key}",
+            score=score,
+            normalized_score=score,
+            details={
+                "detected": detected,
+                "analysis": entry.get("analysis", ""),
+            },
+        )
+    return sub_metrics

--- a/src/eva/metrics/validation/user_behavioral_fidelity.py
+++ b/src/eva/metrics/validation/user_behavioral_fidelity.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
 from eva.metrics.registry import register_metric
+from eva.metrics.utils import build_binary_flag_sub_metrics
 from eva.models.results import MetricScore
 
 _USER_BEHAVIORAL_FIDELITY_CORRUPTION_KEYS = (
@@ -93,9 +94,15 @@ class UserBehavioralFidelityMetric(ConversationTextJudgeMetric):
         context: MetricContext,
         raw_response: str | None = None,
     ) -> MetricScore:
-        """Build MetricScore with corruption analysis details and per-type sub-metrics."""
+        """Build MetricScore with corruption analysis details and per-type detection sub-metrics."""
         corruption_analysis = response.get("corruption_analysis", {}) or {}
-        sub_metrics = _build_corruption_sub_metrics(self.name, corruption_analysis)
+        sub_metrics = build_binary_flag_sub_metrics(
+            parent_name=self.name,
+            entries=corruption_analysis,
+            entry_keys=_USER_BEHAVIORAL_FIDELITY_CORRUPTION_KEYS,
+            flag_field="detected",
+            detail_fields=("analysis",),
+        )
 
         return MetricScore(
             name=self.name,
@@ -111,31 +118,3 @@ class UserBehavioralFidelityMetric(ConversationTextJudgeMetric):
             },
             sub_metrics=sub_metrics or None,
         )
-
-
-def _build_corruption_sub_metrics(
-    parent_name: str,
-    corruption_analysis: dict[str, Any],
-) -> dict[str, MetricScore]:
-    """Build sub-metrics for each corruption type in the judge response.
-
-    Each corruption entry has ``detected`` (bool) and ``analysis`` (str).
-    Sub-metric convention: score = 1.0 if clean (not detected), 0.0 if detected.
-    """
-    sub_metrics: dict[str, MetricScore] = {}
-    for key in _USER_BEHAVIORAL_FIDELITY_CORRUPTION_KEYS:
-        entry = corruption_analysis.get(key)
-        if not isinstance(entry, dict) or "detected" not in entry:
-            continue
-        detected = bool(entry.get("detected"))
-        score = 0.0 if detected else 1.0
-        sub_metrics[key] = MetricScore(
-            name=f"{parent_name}.{key}",
-            score=score,
-            normalized_score=score,
-            details={
-                "detected": detected,
-                "analysis": entry.get("analysis", ""),
-            },
-        )
-    return sub_metrics

--- a/src/eva/metrics/validation/user_behavioral_fidelity.py
+++ b/src/eva/metrics/validation/user_behavioral_fidelity.py
@@ -108,7 +108,6 @@ class UserBehavioralFidelityMetric(ConversationTextJudgeMetric):
             name=self.name,
             score=float(rating),
             normalized_score=normalized,
-            error=None,
             details={
                 "rating": rating,
                 "corrupted": rating == 0,

--- a/src/eva/models/results.py
+++ b/src/eva/models/results.py
@@ -97,15 +97,6 @@ class MetricScore(BaseModel):
     sub_metrics: dict[str, "MetricScore"] | None = Field(
         None, description="Optional sub-metric breakdowns, aggregated generically by the runner"
     )
-    higher_is_better: bool = Field(
-        True,
-        description=(
-            "Direction of the displayed value (normalized_score if present, else score). "
-            "True means higher is better; False means lower is better. Used by the analysis "
-            "app for direction-aware colouring, sorting, and pass/fail semantics. "
-            "Aggregation in the runner is direction-agnostic."
-        ),
-    )
 
 
 class PassAtKResult(BaseModel):

--- a/src/eva/models/results.py
+++ b/src/eva/models/results.py
@@ -97,6 +97,15 @@ class MetricScore(BaseModel):
     sub_metrics: dict[str, "MetricScore"] | None = Field(
         None, description="Optional sub-metric breakdowns, aggregated generically by the runner"
     )
+    higher_is_better: bool = Field(
+        True,
+        description=(
+            "Direction of the displayed value (normalized_score if present, else score). "
+            "True means higher is better; False means lower is better. Used by the analysis "
+            "app for direction-aware colouring, sorting, and pass/fail semantics. "
+            "Aggregation in the runner is direction-agnostic."
+        ),
+    )
 
 
 class PassAtKResult(BaseModel):

--- a/tests/unit/metrics/test_conciseness_judge.py
+++ b/tests/unit/metrics/test_conciseness_judge.py
@@ -52,6 +52,49 @@ async def test_all_turns_rated(metric):
 
 
 @pytest.mark.asyncio
+async def test_surfaces_failure_mode_sub_metrics(metric):
+    """Sub-metrics surface per-failure-mode rates across rated turns."""
+    mock_response = json.dumps(
+        [
+            {"turn_id": 1, "rating": 1, "explanation": "verbose", "failure_modes": ["verbosity_or_filler"]},
+            {
+                "turn_id": 2,
+                "rating": 2,
+                "explanation": "dense",
+                "failure_modes": ["excess_information_density", "verbosity_or_filler"],
+            },
+            {"turn_id": 3, "rating": 3, "explanation": "clean", "failure_modes": []},
+            {"turn_id": 4, "rating": None, "explanation": "user only", "failure_modes": []},
+        ]
+    )
+    metric.llm_client.generate_text = AsyncMock(return_value=mock_response)
+    context = make_metric_context(conversation_trace=SAMPLE_TURNS)
+    result = await metric.compute(context)
+
+    assert result.error is None
+    assert result.sub_metrics is not None
+    expected_keys = {
+        "verbosity_or_filler",
+        "excess_information_density",
+        "over_enumeration_or_list_exhaustion",
+        "contextually_disproportionate_detail",
+    }
+    assert set(result.sub_metrics.keys()) == expected_keys
+    # 2 out of 3 rated turns flagged verbosity_or_filler
+    verbosity = result.sub_metrics["verbosity_or_filler"]
+    assert verbosity.name == "conciseness.verbosity_or_filler"
+    assert verbosity.score == pytest.approx(2 / 3, abs=0.001)
+    assert verbosity.normalized_score == pytest.approx(2 / 3, abs=0.001)
+    assert verbosity.details["count"] == 2
+    assert verbosity.details["num_rated"] == 3
+    assert set(verbosity.details["turn_ids"]) == {1, 2}
+    # modes with zero occurrences still emitted at rate 0
+    over_enum = result.sub_metrics["over_enumeration_or_list_exhaustion"]
+    assert over_enum.score == 0.0
+    assert over_enum.details["count"] == 0
+
+
+@pytest.mark.asyncio
 async def test_null_rating_excluded_from_aggregation(metric):
     """Null ratings (not applicable) are stored but excluded from score."""
     mock_response = json.dumps(

--- a/tests/unit/metrics/test_conciseness_judge.py
+++ b/tests/unit/metrics/test_conciseness_judge.py
@@ -74,22 +74,22 @@ async def test_surfaces_failure_mode_sub_metrics(metric):
     assert result.error is None
     assert result.sub_metrics is not None
     expected_keys = {
-        "verbosity_or_filler",
-        "excess_information_density",
-        "over_enumeration_or_list_exhaustion",
-        "contextually_disproportionate_detail",
+        "verbosity_or_filler_rate",
+        "excess_information_density_rate",
+        "over_enumeration_or_list_exhaustion_rate",
+        "contextually_disproportionate_detail_rate",
     }
     assert set(result.sub_metrics.keys()) == expected_keys
     # 2 out of 3 rated turns flagged verbosity_or_filler
-    verbosity = result.sub_metrics["verbosity_or_filler"]
-    assert verbosity.name == "conciseness.verbosity_or_filler"
+    verbosity = result.sub_metrics["verbosity_or_filler_rate"]
+    assert verbosity.name == "conciseness.verbosity_or_filler_rate"
     assert verbosity.score == pytest.approx(2 / 3, abs=0.001)
     assert verbosity.normalized_score == pytest.approx(2 / 3, abs=0.001)
     assert verbosity.details["count"] == 2
     assert verbosity.details["num_rated"] == 3
     assert set(verbosity.details["turn_ids"]) == {1, 2}
     # modes with zero occurrences still emitted at rate 0
-    over_enum = result.sub_metrics["over_enumeration_or_list_exhaustion"]
+    over_enum = result.sub_metrics["over_enumeration_or_list_exhaustion_rate"]
     assert over_enum.score == 0.0
     assert over_enum.details["count"] == 0
 

--- a/tests/unit/metrics/test_conversation_progression.py
+++ b/tests/unit/metrics/test_conversation_progression.py
@@ -42,6 +42,41 @@ class TestConversationProgression:
         assert score.details["explanation"]["flags_count"] == 0
         assert score.details["num_turns"] == 3
 
+    def test_build_metric_score_surfaces_dimension_sub_metrics(self):
+        ctx = make_metric_context(conversation_trace=[{"role": "user"}, {"role": "assistant"}])
+        response = {
+            "rating": 2,
+            "dimensions": {
+                "unnecessary_tool_calls": {"rating": 3, "flagged": False, "evidence": "clean"},
+                "information_loss": {"rating": 2, "flagged": True, "evidence": "minor"},
+                "redundant_statements": {"rating": 3, "flagged": False, "evidence": ""},
+                "question_quality": {"rating": 1, "flagged": True, "evidence": "bad"},
+            },
+        }
+
+        score = self.metric.build_metric_score(
+            rating=1,
+            normalized=0.0,
+            response=response,
+            prompt="test prompt",
+            context=ctx,
+            raw_response="{...}",
+        )
+
+        assert score.sub_metrics is not None
+        assert set(score.sub_metrics.keys()) == {
+            "unnecessary_tool_calls",
+            "information_loss",
+            "redundant_statements",
+            "question_quality",
+        }
+        q_quality = score.sub_metrics["question_quality"]
+        assert q_quality.name == "conversation_progression.question_quality"
+        assert q_quality.score == 1.0
+        assert q_quality.normalized_score == 0.0
+        assert q_quality.details["flagged"] is True
+        assert q_quality.details["evidence"] == "bad"
+
     @pytest.mark.asyncio
     async def test_compute_excellent(self):
         self.metric.llm_client.generate_text.return_value = json.dumps(

--- a/tests/unit/metrics/test_conversation_progression.py
+++ b/tests/unit/metrics/test_conversation_progression.py
@@ -78,7 +78,6 @@ class TestConversationProgression:
         assert q_quality.details["flagged"] is True
         assert q_quality.details["rating"] == 1
         assert q_quality.details["evidence"] == "bad"
-        assert q_quality.higher_is_better is False
 
         clean = score.sub_metrics["unnecessary_tool_calls_rate"]
         assert clean.score == 0.0

--- a/tests/unit/metrics/test_conversation_progression.py
+++ b/tests/unit/metrics/test_conversation_progression.py
@@ -65,17 +65,24 @@ class TestConversationProgression:
 
         assert score.sub_metrics is not None
         assert set(score.sub_metrics.keys()) == {
-            "unnecessary_tool_calls",
-            "information_loss",
-            "redundant_statements",
-            "question_quality",
+            "unnecessary_tool_calls_rate",
+            "information_loss_rate",
+            "redundant_statements_rate",
+            "question_quality_rate",
         }
-        q_quality = score.sub_metrics["question_quality"]
-        assert q_quality.name == "conversation_progression.question_quality"
-        assert q_quality.score == 1.0
-        assert q_quality.normalized_score == 0.0
+        # Binary issue-flag: 1.0 when flagged, 0.0 when clean; lower is better.
+        q_quality = score.sub_metrics["question_quality_rate"]
+        assert q_quality.name == "conversation_progression.question_quality_rate"
+        assert q_quality.score == 1.0  # flagged
+        assert q_quality.normalized_score == 1.0
         assert q_quality.details["flagged"] is True
+        assert q_quality.details["rating"] == 1
         assert q_quality.details["evidence"] == "bad"
+        assert q_quality.higher_is_better is False
+
+        clean = score.sub_metrics["unnecessary_tool_calls_rate"]
+        assert clean.score == 0.0
+        assert clean.details["flagged"] is False
 
     @pytest.mark.asyncio
     async def test_compute_excellent(self):

--- a/tests/unit/metrics/test_faithfulness.py
+++ b/tests/unit/metrics/test_faithfulness.py
@@ -83,6 +83,70 @@ class TestFaithfulness:
         assert score.score == 0.0
         assert "No transcript" in score.error
 
+    def test_build_metric_score_surfaces_dimension_sub_metrics(self):
+        ctx = make_metric_context(conversation_trace=[{"role": "user"}, {"role": "assistant"}])
+        response = {
+            "rating": 2,
+            "dimensions": {
+                "fabricating_tool_parameters": {"rating": 3, "flagged": False, "evidence": "clean"},
+                "misrepresenting_tool_result": {"rating": 2, "flagged": True, "evidence": "minor"},
+                "violating_policies": {"rating": 3, "flagged": False, "evidence": ""},
+                "failing_to_disambiguate": {"rating": 1, "flagged": True, "evidence": "bad"},
+                "hallucination": {"rating": 3, "flagged": False, "evidence": ""},
+            },
+        }
+
+        score = self.metric.build_metric_score(
+            rating=1,
+            normalized=0.0,
+            response=response,
+            prompt="test prompt",
+            context=ctx,
+            raw_response="{...}",
+        )
+
+        assert score.sub_metrics is not None
+        assert set(score.sub_metrics.keys()) == {
+            "fabricating_tool_parameters",
+            "misrepresenting_tool_result",
+            "violating_policies",
+            "failing_to_disambiguate",
+            "hallucination",
+        }
+        fab = score.sub_metrics["fabricating_tool_parameters"]
+        assert fab.name == "faithfulness.fabricating_tool_parameters"
+        assert fab.score == 3.0
+        assert fab.normalized_score == 1.0
+        assert fab.details["flagged"] is False
+
+        disamb = score.sub_metrics["failing_to_disambiguate"]
+        assert disamb.score == 1.0
+        assert disamb.normalized_score == 0.0
+        assert disamb.details["flagged"] is True
+        assert disamb.details["evidence"] == "bad"
+
+    def test_build_metric_score_skips_missing_or_invalid_dimensions(self):
+        ctx = make_metric_context(conversation_trace=[{"role": "user"}])
+        response = {
+            "rating": 3,
+            "dimensions": {
+                "fabricating_tool_parameters": {"rating": "not-an-int"},
+                "hallucination": {"rating": 3, "flagged": False},
+            },
+        }
+
+        score = self.metric.build_metric_score(
+            rating=3,
+            normalized=1.0,
+            response=response,
+            prompt="p",
+            context=ctx,
+            raw_response="{}",
+        )
+
+        assert score.sub_metrics is not None
+        assert set(score.sub_metrics.keys()) == {"hallucination"}
+
     @pytest.mark.asyncio
     async def test_compute_unparseable_response(self):
         self.metric.llm_client.generate_text.return_value = "not json at all ~~~"

--- a/tests/unit/metrics/test_faithfulness.py
+++ b/tests/unit/metrics/test_faithfulness.py
@@ -107,30 +107,35 @@ class TestFaithfulness:
 
         assert score.sub_metrics is not None
         assert set(score.sub_metrics.keys()) == {
-            "fabricating_tool_parameters",
-            "misrepresenting_tool_result",
-            "violating_policies",
-            "failing_to_disambiguate",
-            "hallucination",
+            "fabricating_tool_parameters_rate",
+            "misrepresenting_tool_result_rate",
+            "violating_policies_rate",
+            "failing_to_disambiguate_rate",
+            "hallucination_rate",
         }
-        fab = score.sub_metrics["fabricating_tool_parameters"]
-        assert fab.name == "faithfulness.fabricating_tool_parameters"
-        assert fab.score == 3.0
-        assert fab.normalized_score == 1.0
+        # Binary issue-flag semantics: 1.0 when flagged, 0.0 when clean.
+        fab = score.sub_metrics["fabricating_tool_parameters_rate"]
+        assert fab.name == "faithfulness.fabricating_tool_parameters_rate"
+        assert fab.score == 0.0  # clean
+        assert fab.normalized_score == 0.0
         assert fab.details["flagged"] is False
+        assert fab.details["rating"] == 3  # raw rating preserved for diagnostics
+        assert fab.higher_is_better is False
 
-        disamb = score.sub_metrics["failing_to_disambiguate"]
-        assert disamb.score == 1.0
-        assert disamb.normalized_score == 0.0
+        disamb = score.sub_metrics["failing_to_disambiguate_rate"]
+        assert disamb.score == 1.0  # flagged
+        assert disamb.normalized_score == 1.0
         assert disamb.details["flagged"] is True
+        assert disamb.details["rating"] == 1
         assert disamb.details["evidence"] == "bad"
+        assert disamb.higher_is_better is False
 
-    def test_build_metric_score_skips_missing_or_invalid_dimensions(self):
+    def test_build_metric_score_skips_dimensions_without_flag(self):
         ctx = make_metric_context(conversation_trace=[{"role": "user"}])
         response = {
             "rating": 3,
             "dimensions": {
-                "fabricating_tool_parameters": {"rating": "not-an-int"},
+                "fabricating_tool_parameters": {"rating": 3},  # no flagged field
                 "hallucination": {"rating": 3, "flagged": False},
             },
         }
@@ -145,7 +150,7 @@ class TestFaithfulness:
         )
 
         assert score.sub_metrics is not None
-        assert set(score.sub_metrics.keys()) == {"hallucination"}
+        assert set(score.sub_metrics.keys()) == {"hallucination_rate"}
 
     @pytest.mark.asyncio
     async def test_compute_unparseable_response(self):

--- a/tests/unit/metrics/test_faithfulness.py
+++ b/tests/unit/metrics/test_faithfulness.py
@@ -120,7 +120,6 @@ class TestFaithfulness:
         assert fab.normalized_score == 0.0
         assert fab.details["flagged"] is False
         assert fab.details["rating"] == 3  # raw rating preserved for diagnostics
-        assert fab.higher_is_better is False
 
         disamb = score.sub_metrics["failing_to_disambiguate_rate"]
         assert disamb.score == 1.0  # flagged
@@ -128,7 +127,6 @@ class TestFaithfulness:
         assert disamb.details["flagged"] is True
         assert disamb.details["rating"] == 1
         assert disamb.details["evidence"] == "bad"
-        assert disamb.higher_is_better is False
 
     def test_build_metric_score_skips_dimensions_without_flag(self):
         ctx = make_metric_context(conversation_trace=[{"role": "user"}])

--- a/tests/unit/metrics/test_runner.py
+++ b/tests/unit/metrics/test_runner.py
@@ -706,6 +706,61 @@ class TestBuildPerMetricAggregates:
         assert result["m"]["none_count"] == 2
         assert result["m"]["mean"] is None
 
+    def test_higher_is_better_read_from_registered_metric(self):
+        """Parent direction is looked up on the metric class, not stored per-record."""
+        # response_speed is registered with higher_is_better=False on its class.
+        all_metrics = {
+            "r1": RecordMetrics(
+                record_id="r1",
+                metrics={"response_speed": MetricScore(name="response_speed", score=1.2, normalized_score=None)},
+            ),
+        }
+        result = MetricsRunner._build_per_metric_aggregates(all_metrics, ["response_speed"])
+        assert result["response_speed"]["higher_is_better"] is False
+
+    def test_higher_is_better_defaults_true_for_unknown_metric(self):
+        """An unregistered metric name defaults to higher_is_better=True."""
+        all_metrics = {
+            "r1": RecordMetrics(record_id="r1", metrics={"m": MetricScore(name="m", score=0.3)}),
+        }
+        result = MetricsRunner._build_per_metric_aggregates(all_metrics, ["m"])
+        assert result["m"]["higher_is_better"] is True
+
+    def test_sub_metric_direction_derived_from_suffix(self):
+        """Sub-metric direction is derived from the key suffix, not stored per-record.
+
+        ``_rate`` suffix → lower is better, ``_accuracy`` → higher is better,
+        otherwise the sub-metric inherits the parent direction.
+        """
+        rate_sub = MetricScore(name="faithfulness.hallucination_rate", score=1.0, normalized_score=1.0)
+        accuracy_sub = MetricScore(
+            name="transcription_accuracy_key_entities.name_accuracy", score=0.8, normalized_score=0.8
+        )
+        all_metrics = {
+            "r1": RecordMetrics(
+                record_id="r1",
+                metrics={
+                    "faithfulness": MetricScore(
+                        name="faithfulness",
+                        score=2.0,
+                        normalized_score=0.5,
+                        sub_metrics={"hallucination_rate": rate_sub},
+                    ),
+                    "transcription_accuracy_key_entities": MetricScore(
+                        name="transcription_accuracy_key_entities",
+                        score=0.8,
+                        normalized_score=0.8,
+                        sub_metrics={"name_accuracy": accuracy_sub},
+                    ),
+                },
+            ),
+        }
+        result = MetricsRunner._build_per_metric_aggregates(
+            all_metrics, ["faithfulness", "transcription_accuracy_key_entities"]
+        )
+        assert result["faithfulness"]["sub_metrics"]["hallucination_rate"]["higher_is_better"] is False
+        assert result["transcription_accuracy_key_entities"]["sub_metrics"]["name_accuracy"]["higher_is_better"] is True
+
 
 class TestBuildDataQuality:
     """Tests for MetricsRunner._build_data_quality splitting error vs missing records."""

--- a/tests/unit/metrics/test_stt_wer_metric.py
+++ b/tests/unit/metrics/test_stt_wer_metric.py
@@ -33,6 +33,32 @@ class TestSTTWERMetricCompute:
         assert result.normalized_score == result.details["accuracy"]
 
     @pytest.mark.asyncio
+    async def test_surfaces_component_sub_metrics(self):
+        """Sub-metrics surface substitution, deletion, insertion rates over reference words."""
+        metric = STTWERMetric()
+        ctx = make_metric_context(
+            intended_user_turns={1: "the quick brown fox jumps"},
+            transcribed_user_turns={1: "the quick green fox"},
+        )
+        result = await metric.compute(ctx)
+
+        assert result.sub_metrics is not None
+        assert set(result.sub_metrics.keys()) == {"substitution_rate", "deletion_rate", "insertion_rate"}
+
+        sub_count = result.sub_metrics["substitution_rate"]
+        del_count = result.sub_metrics["deletion_rate"]
+        ins_count = result.sub_metrics["insertion_rate"]
+        ref_words = result.details["reference_words"]
+        assert ref_words == 5
+        assert sub_count.name == "stt_wer.substitution_rate"
+        assert sub_count.details["reference_words"] == 5
+        assert sub_count.details["count"] == result.details["total_substitutions"]
+        assert del_count.details["count"] == result.details["total_deletions"]
+        assert ins_count.details["count"] == result.details["total_insertions"]
+        assert sub_count.score == pytest.approx(sub_count.details["count"] / ref_words)
+        assert sub_count.normalized_score == sub_count.score
+
+    @pytest.mark.asyncio
     async def test_no_common_turns(self):
         metric = STTWERMetric()
         ctx = make_metric_context(

--- a/tests/unit/metrics/test_tool_call_validity.py
+++ b/tests/unit/metrics/test_tool_call_validity.py
@@ -21,6 +21,65 @@ async def test_no_tool_calls(metric):
     assert result.score == 1.0
     assert result.normalized_score == 1.0
     assert result.details["total_tool_calls"] == 0
+    assert result.sub_metrics is not None
+    assert "num_tool_calls" in result.sub_metrics
+    assert result.sub_metrics["num_tool_calls"].score == 0.0
+    assert result.sub_metrics["num_tool_calls"].normalized_score is None
+
+
+@pytest.mark.asyncio
+async def test_sub_metrics_num_tool_calls_and_error_rates(metric):
+    """Sub-metrics surface num_tool_calls count and per-error-type rates."""
+    tool_params = [
+        {"tool_name": "get_reservation", "tool_parameters": {}},
+        {"tool_name": "get_reservation", "tool_parameters": {}},
+        {"tool_name": "rebook_flight", "tool_parameters": {}},
+        {"tool_name": "search_rebooking_options", "tool_parameters": {}},
+    ]
+    tool_responses = [
+        {
+            "tool_name": "get_reservation",
+            "tool_response": {"status": "error", "error_type": "invalid_parameter", "message": "bad"},
+        },
+        {
+            "tool_name": "get_reservation",
+            "tool_response": {"status": "error", "error_type": "invalid_parameter", "message": "bad"},
+        },
+        {
+            "tool_name": "rebook_flight",
+            "tool_response": {"status": "error", "error_type": "execution_error", "message": "boom"},
+        },
+        {
+            "tool_name": "search_rebooking_options",
+            "tool_response": {"status": "success"},
+        },
+    ]
+    context = make_metric_context(tool_params=tool_params, tool_responses=tool_responses)
+    result = await metric.compute(context)
+
+    assert result.sub_metrics is not None
+    count_sub = result.sub_metrics["num_tool_calls"]
+    assert count_sub.name == "tool_call_validity.num_tool_calls"
+    assert count_sub.score == 4.0
+    assert count_sub.normalized_score is None
+
+    # Every known error type has a sub-metric (rate = 0 when absent).
+    for error_type in CALL_ERROR_TYPES:
+        key = f"{error_type}_rate"
+        assert key in result.sub_metrics
+
+    inv = result.sub_metrics["invalid_parameter_rate"]
+    assert inv.score == pytest.approx(0.5)
+    assert inv.normalized_score == pytest.approx(0.5)
+    assert inv.details == {"count": 2, "total_tool_calls": 4}
+
+    exec_err = result.sub_metrics["execution_error_rate"]
+    assert exec_err.score == pytest.approx(0.25)
+    assert exec_err.details == {"count": 1, "total_tool_calls": 4}
+
+    tool_not_found = result.sub_metrics["tool_not_found_rate"]
+    assert tool_not_found.score == 0.0
+    assert tool_not_found.details == {"count": 0, "total_tool_calls": 4}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/metrics/test_transcription_accuracy_key_entities.py
+++ b/tests/unit/metrics/test_transcription_accuracy_key_entities.py
@@ -164,6 +164,52 @@ def metric():
 
 class TestCompute:
     @pytest.mark.asyncio
+    async def test_surfaces_per_entity_type_sub_metrics(self, metric):
+        """Sub-metrics aggregate accuracy per entity type across turns."""
+        context = make_metric_context(
+            intended_user_turns={0: "My name is John Smith", 1: "Confirmation ABC123 on Dec 15"},
+            transcribed_user_turns={0: "My name is John Smith", 1: "Confirmation ABC123 on Dec 15"},
+        )
+        response = _make_judge_response(
+            [
+                {
+                    "turn_id": 0,
+                    "summary": "mostly correct",
+                    "entities": [
+                        {"type": "name", "correct": True, "skipped": False},
+                        {"type": "name", "correct": False, "skipped": False},
+                    ],
+                },
+                {
+                    "turn_id": 1,
+                    "summary": "one skipped",
+                    "entities": [
+                        {"type": "confirmation_code", "correct": True, "skipped": False},
+                        {"type": "date", "correct": True, "skipped": False},
+                        {"type": "date", "correct": False, "skipped": True},
+                    ],
+                },
+            ]
+        )
+        metric.llm_client.generate_text = AsyncMock(return_value=response)
+
+        result = await metric.compute(context)
+
+        assert result.error is None
+        assert result.sub_metrics is not None
+        assert set(result.sub_metrics.keys()) == {"name", "confirmation_code", "date"}
+        name_sub = result.sub_metrics["name"]
+        assert name_sub.name == "transcription_accuracy_key_entities.name"
+        assert name_sub.score == pytest.approx(0.5)
+        assert name_sub.details == {"correct": 1, "total_non_skipped": 2, "skipped": 0}
+        code_sub = result.sub_metrics["confirmation_code"]
+        assert code_sub.score == 1.0
+        assert code_sub.details == {"correct": 1, "total_non_skipped": 1, "skipped": 0}
+        date_sub = result.sub_metrics["date"]
+        assert date_sub.score == 1.0
+        assert date_sub.details == {"correct": 1, "total_non_skipped": 1, "skipped": 1}
+
+    @pytest.mark.asyncio
     async def test_all_turns_have_entities(self, metric):
         """All turns have entities -> num_evaluated == num_turns, num_not_applicable == 0."""
         context = make_metric_context(

--- a/tests/unit/metrics/test_transcription_accuracy_key_entities.py
+++ b/tests/unit/metrics/test_transcription_accuracy_key_entities.py
@@ -197,15 +197,20 @@ class TestCompute:
 
         assert result.error is None
         assert result.sub_metrics is not None
-        assert set(result.sub_metrics.keys()) == {"name", "confirmation_code", "date"}
-        name_sub = result.sub_metrics["name"]
-        assert name_sub.name == "transcription_accuracy_key_entities.name"
+        assert set(result.sub_metrics.keys()) == {
+            "name_accuracy",
+            "confirmation_code_accuracy",
+            "date_accuracy",
+        }
+        name_sub = result.sub_metrics["name_accuracy"]
+        assert name_sub.name == "transcription_accuracy_key_entities.name_accuracy"
         assert name_sub.score == pytest.approx(0.5)
         assert name_sub.details == {"correct": 1, "total_non_skipped": 2, "skipped": 0}
-        code_sub = result.sub_metrics["confirmation_code"]
+        assert name_sub.higher_is_better is True
+        code_sub = result.sub_metrics["confirmation_code_accuracy"]
         assert code_sub.score == 1.0
         assert code_sub.details == {"correct": 1, "total_non_skipped": 1, "skipped": 0}
-        date_sub = result.sub_metrics["date"]
+        date_sub = result.sub_metrics["date_accuracy"]
         assert date_sub.score == 1.0
         assert date_sub.details == {"correct": 1, "total_non_skipped": 1, "skipped": 1}
 

--- a/tests/unit/metrics/test_transcription_accuracy_key_entities.py
+++ b/tests/unit/metrics/test_transcription_accuracy_key_entities.py
@@ -206,7 +206,6 @@ class TestCompute:
         assert name_sub.name == "transcription_accuracy_key_entities.name_accuracy"
         assert name_sub.score == pytest.approx(0.5)
         assert name_sub.details == {"correct": 1, "total_non_skipped": 2, "skipped": 0}
-        assert name_sub.higher_is_better is True
         code_sub = result.sub_metrics["confirmation_code_accuracy"]
         assert code_sub.score == 1.0
         assert code_sub.details == {"correct": 1, "total_non_skipped": 1, "skipped": 0}

--- a/tests/unit/metrics/test_user_behavioral_fidelity.py
+++ b/tests/unit/metrics/test_user_behavioral_fidelity.py
@@ -81,6 +81,67 @@ class TestUserBehavioralFidelity:
         assert score.score == 0.0
         assert score.details["corrupted"] is True
 
+    def test_build_metric_score_surfaces_corruption_sub_metrics(self):
+        ctx = make_metric_context()
+        response = {
+            "corruption_analysis": {
+                "extra_modifications": {"detected": False, "analysis": "none"},
+                "premature_ending": {"detected": True, "analysis": "ended early"},
+                "missing_information": {"detected": False, "analysis": ""},
+                "duplicate_modifications": {"detected": False, "analysis": ""},
+                "decision_tree_violation": {"detected": False, "analysis": ""},
+            }
+        }
+
+        score = self.metric.build_metric_score(
+            rating=0,
+            normalized=0.0,
+            response=response,
+            prompt="test",
+            context=ctx,
+        )
+
+        assert score.sub_metrics is not None
+        assert set(score.sub_metrics.keys()) == {
+            "extra_modifications",
+            "premature_ending",
+            "missing_information",
+            "duplicate_modifications",
+            "decision_tree_violation",
+        }
+        extra = score.sub_metrics["extra_modifications"]
+        assert extra.name == "user_behavioral_fidelity.extra_modifications"
+        assert extra.score == 1.0  # clean
+        assert extra.normalized_score == 1.0
+        assert extra.details["detected"] is False
+
+        premature = score.sub_metrics["premature_ending"]
+        assert premature.score == 0.0  # detected
+        assert premature.normalized_score == 0.0
+        assert premature.details["detected"] is True
+        assert premature.details["analysis"] == "ended early"
+
+    def test_build_metric_score_skips_malformed_corruption_entries(self):
+        ctx = make_metric_context()
+        response = {
+            "corruption_analysis": {
+                "extra_modifications": {"detected": False},
+                "premature_ending": "not-a-dict",  # malformed
+                "missing_information": {},  # no detected key
+            }
+        }
+
+        score = self.metric.build_metric_score(
+            rating=1,
+            normalized=1.0,
+            response=response,
+            prompt="test",
+            context=ctx,
+        )
+
+        assert score.sub_metrics is not None
+        assert set(score.sub_metrics.keys()) == {"extra_modifications"}
+
     @pytest.mark.asyncio
     async def test_compute_not_corrupted(self):
         self.metric.llm_client.generate_text.return_value = json.dumps(

--- a/tests/unit/metrics/test_user_behavioral_fidelity.py
+++ b/tests/unit/metrics/test_user_behavioral_fidelity.py
@@ -115,14 +115,12 @@ class TestUserBehavioralFidelity:
         assert extra.score == 0.0  # clean
         assert extra.normalized_score == 0.0
         assert extra.details["detected"] is False
-        assert extra.higher_is_better is False
 
         premature = score.sub_metrics["premature_ending_rate"]
         assert premature.score == 1.0  # detected
         assert premature.normalized_score == 1.0
         assert premature.details["detected"] is True
         assert premature.details["analysis"] == "ended early"
-        assert premature.higher_is_better is False
 
     def test_build_metric_score_skips_malformed_corruption_entries(self):
         ctx = make_metric_context()

--- a/tests/unit/metrics/test_user_behavioral_fidelity.py
+++ b/tests/unit/metrics/test_user_behavioral_fidelity.py
@@ -103,23 +103,26 @@ class TestUserBehavioralFidelity:
 
         assert score.sub_metrics is not None
         assert set(score.sub_metrics.keys()) == {
-            "extra_modifications",
-            "premature_ending",
-            "missing_information",
-            "duplicate_modifications",
-            "decision_tree_violation",
+            "extra_modifications_rate",
+            "premature_ending_rate",
+            "missing_information_rate",
+            "duplicate_modifications_rate",
+            "decision_tree_violation_rate",
         }
-        extra = score.sub_metrics["extra_modifications"]
-        assert extra.name == "user_behavioral_fidelity.extra_modifications"
-        assert extra.score == 1.0  # clean
-        assert extra.normalized_score == 1.0
+        # Binary detection: 1.0 when corruption detected, 0.0 when clean; lower is better.
+        extra = score.sub_metrics["extra_modifications_rate"]
+        assert extra.name == "user_behavioral_fidelity.extra_modifications_rate"
+        assert extra.score == 0.0  # clean
+        assert extra.normalized_score == 0.0
         assert extra.details["detected"] is False
+        assert extra.higher_is_better is False
 
-        premature = score.sub_metrics["premature_ending"]
-        assert premature.score == 0.0  # detected
-        assert premature.normalized_score == 0.0
+        premature = score.sub_metrics["premature_ending_rate"]
+        assert premature.score == 1.0  # detected
+        assert premature.normalized_score == 1.0
         assert premature.details["detected"] is True
         assert premature.details["analysis"] == "ended early"
+        assert premature.higher_is_better is False
 
     def test_build_metric_score_skips_malformed_corruption_entries(self):
         ctx = make_metric_context()
@@ -140,7 +143,7 @@ class TestUserBehavioralFidelity:
         )
 
         assert score.sub_metrics is not None
-        assert set(score.sub_metrics.keys()) == {"extra_modifications"}
+        assert set(score.sub_metrics.keys()) == {"extra_modifications_rate"}
 
     @pytest.mark.asyncio
     async def test_compute_not_corrupted(self):


### PR DESCRIPTION
## Summary

Adds sub-metric breakdowns to existing metrics so results can be analyzed at a finer grain (per error type, per failure mode, per dimension, per entity type) without having to add new top-level metrics. Also threads a `higher_is_better` signal through the metric base class, aggregator, and analysis app so lower-is-better metrics are rendered correctly.

## Framework changes

- `BaseMetric.higher_is_better` class attribute. Default `True`; override on the class (e.g., latency metrics) rather than per record.
- New helpers in `eva.metrics.utils`:
  - `make_rate_sub_metric(...)` — rate-style sub-metric where `score == normalized_score == numerator / denominator`.
  - `build_binary_flag_sub_metrics(...)` — one sub-metric per dimension/corruption type with `score = 1.0` when the judge flagged it (aggregated mean reads as an issue-occurrence rate).
  - `direction_for_sub_metric(...)` — derives direction from the key suffix: `_rate` → lower-is-better, `_accuracy` → higher-is-better, otherwise inherit the parent.
- `PerTurnConversationJudgeMetric.build_sub_metrics(context, per_turn_ratings, per_turn_extra)` hook for subclasses to surface per-turn breakdowns.
- `MetricsRunner` now writes `higher_is_better` on every metric and sub-metric entry in the run-level aggregates, reading the parent direction from the registry.

## Per-metric sub-metrics added

- `stt_wer`: `substitution_rate`, `deletion_rate`, `insertion_rate` (component / reference-word count).
- `tool_call_validity`: `num_tool_calls` (count, non-normalized) + one `*_rate` per error type in `CALL_ERROR_TYPES`.
- `conciseness_judge`: one `<failure_mode>_rate` per failure mode, over rated turns.
- `conversation_progression_judge`: one `<dimension>_rate` per dimension (binary flagged).
- `faithfulness_judge`: one `<dimension>_rate` per dimension (binary flagged).
- `transcription_accuracy_key_entities`: one `<entity_type>_accuracy` per entity type seen in the run.
- `user_behavioral_fidelity`: one `<corruption_type>_rate` per corruption type (binary detected).

## Analysis app

- Prefixes lower-is-better labels with `↓` (parent direction from the registry; sub-metric direction from the key suffix).
- Supports non-normalized sub-metrics like `tool_call_validity__num_tool_calls` (count axis, no hover suffix).
- Bar ordering, query-param-driven state, and error surfacing in the analysis view.

## Test plan

- [x] `pytest tests/unit/metrics` — unit tests added for each metric's sub-metric output (conciseness, conversation progression, faithfulness, STT WER, tool call validity, transcription accuracy key entities, user behavioral fidelity) and for the runner's sub-metric aggregation with `higher_is_better`.
- [x] Spot-check the analysis app against a recent run — confirm `↓` prefix on lower-is-better metrics and that `tool_call_validity__num_tool_calls` renders on the count axis.