### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v6
+        with:
+          python-version-file: pyproject.toml
 
       - name: Cache pip packages
         uses: actions/cache@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
           commit_message: Apply pre-commit
 
       - name: Run tests
-        run: uv run pytest tests/ --cov=eva --cov-report=term-missing
+        run: uv run pytest tests/ --color=yes --cov=eva --cov-report=term-missing --durations=10
 
       - name: Fail if pre-commit failed
         if: steps.run-pre-commit.outcome == 'failure'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,21 +19,16 @@ jobs:
         with:
           ref: ${{ github.head_ref }}  # Required in non-push events for git-auto-commit-action to work.
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version-file: pyproject.toml
 
-      - name: Cache pip packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
-
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv sync --extra dev --frozen
 
       - name: Run pre-commit
         id: run-pre-commit
@@ -46,7 +41,7 @@ jobs:
           commit_message: Apply pre-commit
 
       - name: Run tests
-        run: pytest tests/ --cov=eva --cov-report=term-missing
+        run: uv run pytest tests/ --cov=eva --cov-report=term-missing
 
       - name: Fail if pre-commit failed
         if: steps.run-pre-commit.outcome == 'failure'


### PR DESCRIPTION
* [Set python version in CI](https://github.com/ServiceNow/eva/pull/66/commits/e032bfd8a46185436ef741b7147053d1f9df63e9) 
  The `actions/setup-python` is showing a warning since we removed the `.python-version` file.
* [Install locked dependencies](https://github.com/ServiceNow/eva/pull/66/commits/37d84a941c1610b90172c5d5b66836f96535ef20) with uv.
  This fixes an issue with a breaking change in the latest `pydantic-settings`.
  Also drop the "Cache pip packages" step since uv already manages a cache.
* [Add color to pytest](https://github.com/ServiceNow/eva/pull/66/commits/37dcfa7da0de2ae2ef05e0f364c19e9f3d3493ae) and print the duration of the slowest 10 tests.