### PR TITLE
Fix crash in STT/TTS latency calc on TurnMetricsData entries

### DIFF
--- a/src/eva/orchestrator/worker.py
+++ b/src/eva/orchestrator/worker.py
@@ -338,15 +338,28 @@ class ConversationWorker:
         try:
             latencies = []
             with open(metrics_path) as f:
-                for line in f:
-                    metric = json.loads(line)
-                    value_sec = metric.get("value")
-                    if not value_sec or not (0 < value_sec < 30):
+                for line_num, line in enumerate(f, start=1):
+                    try:
+                        metric = json.loads(line)
+                        metric_type = metric.get("type")
+                        is_stt_processing = metric_type == "ProcessingMetricsData" and "STTService" in metric.get(
+                            "processor", ""
+                        )
+                        is_stt_latency = metric_type == "LatencyMetric" and metric.get("stage") == "stt"
+                        if not (is_stt_processing or is_stt_latency):
+                            continue
+                        value_sec = metric.get("value")
+                        if not isinstance(value_sec, (int, float)) or not (0 < value_sec < 30):
+                            continue
+                        latencies.append(value_sec * 1000)
+                    except Exception as line_err:
+                        logger.warning(
+                            f"STT latency: skipping malformed entry at line {line_num} "
+                            f"({type(line_err).__name__}: {line_err}); "
+                            f"value={metric.get('value')!r} (type={type(metric.get('value')).__name__}), "
+                            f"metric_type={metric.get('type')!r}, raw={line.strip()[:500]}"
+                        )
                         continue
-                    if metric.get("type") == "ProcessingMetricsData" and "STTService" in metric.get("processor", ""):
-                        latencies.append(value_sec * 1000)
-                    elif metric.get("type") == "LatencyMetric" and metric.get("stage") == "stt":
-                        latencies.append(value_sec * 1000)
 
             if not latencies:
                 return None
@@ -361,8 +374,8 @@ class ConversationWorker:
                 total_calls=n,
             )
 
-        except Exception as e:
-            logger.warning(f"Failed to calculate STT latency: {e}")
+        except Exception:
+            logger.exception("Failed to calculate STT latency")
             return None
 
     def _calculate_tts_latency(self) -> LatencyStats | None:
@@ -378,15 +391,26 @@ class ConversationWorker:
         try:
             latencies = []
             with open(metrics_path) as f:
-                for line in f:
-                    metric = json.loads(line)
-                    value_sec = metric.get("value")
-                    if not value_sec or not (0 < value_sec < 10):
+                for line_num, line in enumerate(f, start=1):
+                    try:
+                        metric = json.loads(line)
+                        metric_type = metric.get("type")
+                        is_tts_ttfb = metric_type == "TTFBMetricsData" and "TTSService" in metric.get("processor", "")
+                        is_tts_latency = metric_type == "LatencyMetric" and metric.get("stage") == "tts"
+                        if not (is_tts_ttfb or is_tts_latency):
+                            continue
+                        value_sec = metric.get("value")
+                        if not isinstance(value_sec, (int, float)) or not (0 < value_sec < 10):
+                            continue
+                        latencies.append(value_sec * 1000)
+                    except Exception as line_err:
+                        logger.warning(
+                            f"TTS latency: skipping malformed entry at line {line_num} "
+                            f"({type(line_err).__name__}: {line_err}); "
+                            f"value={metric.get('value')!r} (type={type(metric.get('value')).__name__}), "
+                            f"metric_type={metric.get('type')!r}, raw={line.strip()[:500]}"
+                        )
                         continue
-                    if metric.get("type") == "TTFBMetricsData" and "TTSService" in metric.get("processor", ""):
-                        latencies.append(value_sec * 1000)
-                    elif metric.get("type") == "LatencyMetric" and metric.get("stage") == "tts":
-                        latencies.append(value_sec * 1000)
 
             if not latencies:
                 return None
@@ -401,8 +425,8 @@ class ConversationWorker:
                 total_calls=n,
             )
 
-        except Exception as e:
-            logger.warning(f"Failed to calculate TTS latency: {e}")
+        except Exception:
+            logger.exception("Failed to calculate TTS latency")
             return None
 
     def _calculate_model_response_latency(self) -> LatencyStats | None:


### PR DESCRIPTION
## Summary
- Latency calculators in `ConversationWorker` crashed the entire pass (returning `None` for STT/TTS latency) whenever `pipecat_metrics.jsonl` contained a `TurnMetricsData` entry, because Pipecat's smart-turn detector writes a dict-shaped `value` (`{is_complete, probability, e2e_processing_time_ms}`) and the numeric range check `0 < value_sec < N` ran *before* the type filter.
- Reordered both `_calculate_stt_latency` and `_calculate_tts_latency` to filter by `type` / `processor` / `stage` first, then validate `value` is numeric via `isinstance` before multiplying.
- Wrapped per-line parsing in try/except so a single malformed entry no longer aborts the whole file. On skip we log the line number, the `value` and its Python type, the `metric.type`, and the truncated raw JSON — so future shape surprises surface as warnings instead of silently losing all latency data.
- Upgraded the outer catch to `logger.exception` for a traceback if something unexpected does slip through.

## Symptom that triggered this
```
Failed to calculate TTS latency: '<' not supported between instances of 'int' and 'dict'
```
Raw offending entry:
```json
{"type": "TurnMetricsData", "processor": "BaseSmartTurn", "value": {"is_complete": false, "probability": 0.028, "e2e_processing_time_ms": 51.2}}
```

## Test plan
- [ ] Run a benchmark whose `pipecat_metrics.jsonl` contains `TurnMetricsData` entries and confirm `latency.stt` / `latency.tts` are populated in the result instead of `null`.
- [ ] Confirm no regression on runs that only contain `ProcessingMetricsData` / `TTFBMetricsData` / `LatencyMetric` entries — latency numbers should match prior runs.
- [ ] If a malformed entry is introduced, verify the warning log now prints line number, `value` type, and raw JSON and processing continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)