### PR TITLE
Improve airline agent: enum schemas, policy consistency, same-day fee fix

### DIFF
--- a/configs/agents/airline_agent.yaml
+++ b/configs/agents/airline_agent.yaml
@@ -44,7 +44,7 @@ instructions: |
   
   Same-Day Changes:
   - Same-day confirmed change: $75 (waived for elite status Gold and above)
-  - Same-day standby: Free for all fare classes
+  - Same-day standby: Free (see Standby Rules)
   
   Fee Waivers:
   - IRROPS (cancellation, delay >2hrs, schedule change >2hrs): All fees waived
@@ -114,9 +114,9 @@ instructions: |
   ### Standby Rules
   
   Eligibility:
+  - Free for all passengers, all fare classes
   - Available on same-day flights only
   - Passenger must have confirmed seat on a later flight same day
-  - Not available for Basic Economy fares
   
   Priority Order:
   - 1. Elite Platinum members
@@ -148,16 +148,13 @@ instructions: |
   
   Silver:
   - Priority standby listing
-  - Waived same-day standby fee
-  
+
   Gold:
   - Priority standby listing
-  - Waived same-day standby fee
   - Waived same-day confirmed change fee
-  
+
   Platinum:
   - Priority standby listing
-  - Waived same-day standby fee
   - Waived same-day confirmed change fee
   - Waived voluntary change fees
   - Complimentary upgrades when available

--- a/configs/agents/airline_agent.yaml
+++ b/configs/agents/airline_agent.yaml
@@ -170,6 +170,8 @@ instructions: |
   - Unresolved complaint after 2 attempts
   - Technical system issues arise
 
+  Always offer the transfer first and wait for the caller to explicitly confirm before initiating it.
+
 tools:
 - id: get_reservation
   name: get_reservation

--- a/configs/agents/airline_agent.yaml
+++ b/configs/agents/airline_agent.yaml
@@ -34,16 +34,23 @@ instructions: |
   ## Policies
   
   ### Change Fees
-  
-  Voluntary Changes:
-  - Basic Economy: $199 change fee + fare difference
+
+  "Same-day" means the new flight departs on today's calendar date. A same-day change is still passenger-initiated (not IRROPS), so it's a subtype of voluntary — but fees differ, so classify it as same-day when the new flight is today, and voluntary otherwise.
+
+  Voluntary changes (passenger-initiated, new flight on a future date):
+  - Basic Economy: $75 change fee + fare difference
   - Main Cabin Economy: $75 change fee + fare difference
   - Premium Economy: $75 change fee + fare difference
   - Business Class: No change fee, fare difference only
   - First Class: No change fee, fare difference only
-  
-  Same-Day Changes:
-  - Same-day confirmed change: $75 (waived for elite status Gold and above)
+
+  Same-day changes (passenger-initiated, new flight departing today):
+  - Basic Economy: $199 change fee + fare difference
+  - Main Cabin Economy: $75 change fee + fare difference
+  - Premium Economy: $75 change fee + fare difference
+  - Business Class: $75 change fee + fare difference
+  - First Class: $75 change fee + fare difference
+  - Fees waived for Gold and Platinum elite status
   - Same-day standby: Free (see Standby Rules)
   
   Fee Waivers:

--- a/configs/agents/airline_agent.yaml
+++ b/configs/agents/airline_agent.yaml
@@ -230,7 +230,8 @@ tools:
     description: Number of passengers needing seats
   - name: fare_class
     type: string
-    description: Fare class to search (basic_economy, main_cabin, premium_economy, business, first, any)
+    enum: [basic_economy, main_cabin, premium_economy, business, first, any]
+    description: Fare class to search. Use 'any' for cheapest available.
 
 - id: rebook_flight
   name: rebook_flight
@@ -249,15 +250,16 @@ tools:
     description: Journey ID of the replacement flight from search_rebooking_options
   - name: rebooking_type
     type: string
-    description: Reason for rebooking (voluntary, same_day, irrops_cancellation, irrops_delay, irrops_schedule_change, missed_flight_passenger_fault,
-      missed_connection_airline_fault)
+    enum: [voluntary, same_day, irrops_cancellation, irrops_delay, irrops_schedule_change, missed_flight_passenger_fault, missed_connection_airline_fault]
+    description: Reason for rebooking
   - name: waive_change_fee
     type: boolean
     description: Whether to waive the change fee (only valid for voluntary changes with authorization)
   optional_parameters:
   - name: new_fare_class
     type: string
-    description: Fare class to rebook into if changing cabin (basic_economy, main_cabin, premium_economy, business, first). Omit to keep original fare class.
+    enum: [basic_economy, main_cabin, premium_economy, business, first]
+    description: Fare class to rebook into if changing cabin. Omit to keep original fare class.
   - name: flight_number
     type: string
     description: For multi-segment journeys, the specific flight number of the leg to replace (partial rebook). Omit for full journey rebook.
@@ -297,7 +299,8 @@ tools:
     description: Journey ID from get_reservation
   - name: seat_preference
     type: string
-    description: Seat preference (window, aisle, middle, no_preference)
+    enum: [window, aisle, middle, no_preference]
+    description: Seat preference
   optional_parameters:
   - name: flight_number
     type: string
@@ -340,7 +343,8 @@ tools:
     description: Journey ID from get_reservation
   - name: meal_type
     type: string
-    description: Meal type (vegetarian, vegan, kosher, halal, gluten_free, diabetic, low_sodium, child, hindu, standard, none)
+    enum: [vegetarian, vegan, kosher, halal, gluten_free, diabetic, low_sodium, child, hindu, standard, none]
+    description: Meal type
   optional_parameters:
   - name: flight_number
     type: string
@@ -363,7 +367,8 @@ tools:
     description: Credit amount in USD
   - name: credit_reason
     type: string
-    description: Reason for credit (cancellation_non_refundable, fare_difference_negative, service_recovery, goodwill, downgrade_compensation)
+    enum: [cancellation_non_refundable, fare_difference_negative, service_recovery, goodwill, downgrade_compensation]
+    description: Reason for credit
 
 - id: issue_hotel_voucher
   name: issue_hotel_voucher
@@ -395,7 +400,8 @@ tools:
     description: Passenger identifier
   - name: voucher_reason
     type: string
-    description: Reason for voucher (delay_over_2_hours, delay_over_4_hours, cancellation_wait_same_day, irrops_overnight)
+    enum: [delay_over_2_hours, delay_over_4_hours, cancellation_wait_same_day, irrops_overnight]
+    description: Reason for voucher
 
 - id: cancel_reservation
   name: cancel_reservation
@@ -411,7 +417,8 @@ tools:
     description: Journey ID of the booking to cancel, from get_reservation bookings list
   - name: cancellation_reason
     type: string
-    description: Reason for cancellation (voluntary, irrops_refund, 24_hour_rule, schedule_unacceptable, medical, bereavement)
+    enum: [voluntary, irrops_refund, 24_hour_rule, schedule_unacceptable, medical, bereavement]
+    description: Reason for cancellation
 
 - id: process_refund
   name: process_refund
@@ -427,7 +434,8 @@ tools:
     description: Amount to refund from cancel_reservation response
   - name: refund_type
     type: string
-    description: Type of refund (full_fare, partial_fare, taxes_only, ancillary_fees)
+    enum: [full_fare, partial_fare, taxes_only, ancillary_fees]
+    description: Type of refund
 
 - id: transfer_to_agent
   name: transfer_to_agent

--- a/src/eva/assistant/tools/airline_params.py
+++ b/src/eva/assistant/tools/airline_params.py
@@ -87,6 +87,16 @@ class RefundType(StrEnum):
     ancillary_fees = "ancillary_fees"
 
 
+class CancellationReason(StrEnum):
+    voluntary = "voluntary"
+    irrops_refund = "irrops_refund"
+    # Prefixed because Python enum members can't start with a digit.
+    rule_24_hour = "24_hour_rule"
+    schedule_unacceptable = "schedule_unacceptable"
+    medical = "medical"
+    bereavement = "bereavement"
+
+
 ConfirmationNumber = Annotated[str, Field(pattern=r"^[A-Za-z0-9]{6}$", description="6 alphanumeric characters")]
 FlightNumberStr = Annotated[
     str, Field(pattern=r"^[A-Za-z]{2,3}\d{1,4}$", description="2-3 letters followed by 1-4 digits", examples=["SK621"])
@@ -188,7 +198,7 @@ class IssueMealVoucherParams(BaseModel):
 class CancelReservationParams(BaseModel):
     confirmation_number: ConfirmationNumber
     journey_id: JourneyIdStr
-    cancellation_reason: str
+    cancellation_reason: CancellationReason
 
 
 class ProcessRefundParams(BaseModel):
@@ -214,6 +224,7 @@ FIELD_ERROR_TYPES: dict[str, tuple[str, str]] = {
     "voucher_reason": ("invalid_voucher_reason", "voucher_reason"),
     "refund_type": ("invalid_refund_type", "refund_type"),
     "seat_preference": ("invalid_seat_preference", "seat_preference"),
+    "cancellation_reason": ("invalid_cancellation_reason", "cancellation_reason"),
     # Format-validated fields
     "confirmation_number": ("invalid_confirmation_number_format", "confirmation_number"),
     "flight_number": ("invalid_flight_number_format", "flight_number"),

--- a/src/eva/assistant/tools/airline_tools.py
+++ b/src/eva/assistant/tools/airline_tools.py
@@ -138,6 +138,29 @@ def _journey_not_found(journey_id: str):
     }
 
 
+def _enrich_booking_with_flight_details(booking: dict, db: dict) -> None:
+    """Merge flight details from the journeys table into a booking in-place.
+
+    Merges per-segment origin/destination/scheduled_departure/scheduled_arrival
+    from the matching journey segment (keyed by flight_number). Leaves the
+    booking untouched if the journey can't be found.
+
+    Operational status (delayed/cancelled, delay_minutes, gate) is intentionally
+    NOT merged — that belongs to get_flight_status.
+    """
+    journey = db.get("journeys", {}).get(booking.get("journey_id"))
+    if not journey:
+        return
+    journey_segs_by_flight = {js.get("flight_number"): js for js in journey.get("segments", [])}
+    for bs in booking.get("segments", []):
+        jseg = journey_segs_by_flight.get(bs.get("flight_number"))
+        if not jseg:
+            continue
+        for field in ("origin", "destination", "scheduled_departure", "scheduled_arrival"):
+            if field in jseg:
+                bs[field] = jseg[field]
+
+
 def get_reservation(params: dict, db: dict, call_index: int) -> dict:
     """Retrieve flight reservation details using confirmation number and passenger last name.
 
@@ -175,6 +198,8 @@ def get_reservation(params: dict, db: dict, call_index: int) -> dict:
 
     # Return success — sort journeys by first segment's date, then journey_id for readability
     result_reservation = copy.deepcopy(reservation)
+    for booking in result_reservation["bookings"]:
+        _enrich_booking_with_flight_details(booking, db)
     result_reservation["bookings"].sort(
         key=lambda j: (
             j.get("segments", [{}])[0].get("date", ""),

--- a/src/eva/assistant/tools/airline_tools.py
+++ b/src/eva/assistant/tools/airline_tools.py
@@ -17,6 +17,7 @@ from eva.assistant.tools.airline_params import (
     AddMealRequestParams,
     AddToStandbyParams,
     AssignSeatParams,
+    CancellationReason,
     CancelReservationParams,
     GetDisruptionInfoParams,
     GetFlightStatusParams,
@@ -1152,21 +1153,9 @@ def cancel_reservation(params: dict, db: dict, call_index: int) -> dict:
     # Compute refund/credit for this booking journey's fare
     booking_fare = _get_booking_total_fare(booking)
 
-    is_refundable = (
-        "irrops_refund" in cancellation_reason
-        or "24_hour_rule" in cancellation_reason
-        or reservation.get("fare_type") == "refundable"
-    )
-
-    cancellation_fee = (
-        0
-        if (
-            "24_hour_rule" in cancellation_reason
-            or "irrops_refund" in cancellation_reason
-            or reservation.get("fare_type") == "refundable"
-        )
-        else 100
-    )
+    fee_waiving_reasons = {CancellationReason.irrops_refund, CancellationReason.rule_24_hour}
+    is_refundable = cancellation_reason in fee_waiving_reasons or reservation.get("fare_type") == "refundable"
+    cancellation_fee = 0 if is_refundable else 100
 
     refund_amount = max(0, booking_fare - cancellation_fee) if is_refundable else 0
     credit_amount = 0 if is_refundable else max(0, booking_fare - cancellation_fee)

--- a/src/eva/assistant/tools/airline_tools.py
+++ b/src/eva/assistant/tools/airline_tools.py
@@ -27,6 +27,7 @@ from eva.assistant.tools.airline_params import (
     IssueTravelCreditParams,
     ProcessRefundParams,
     RebookFlightParams,
+    RebookingType,
     SearchRebookingOptionsParams,
     TransferToAgentParams,
     validation_error_response,
@@ -464,11 +465,19 @@ def rebook_flight(params: dict, db: dict, call_index: int) -> dict:
 
     # Computations
     is_irrops = "irrops" in rebooking_type
+    is_same_day = rebooking_type == RebookingType.same_day
 
-    # Fee calculation — based on ORIGINAL fare class (that's what the passenger paid for)
-    fee_map = {"basic_economy": 199, "main_cabin": 75, "premium_economy": 75, "business": 0, "first": 0}
-    base_fee = fee_map.get(original_fare_class, 75)
-    change_fee = 0 if (is_irrops or waive_change_fee) else base_fee
+    # Fee calculation — based on ORIGINAL fare class (that's what the passenger paid for).
+    # IRROPS and explicit waivers zero the fee. Same-day changes are flat $75 for every
+    # paid fare class, except Basic Economy which carries a $199 penalty. Voluntary
+    # (advance) changes are $75 for economy tiers and free for Business/First.
+    if is_irrops or waive_change_fee:
+        change_fee = 0
+    elif is_same_day:
+        change_fee = 199 if original_fare_class == "basic_economy" else 75
+    else:
+        voluntary_fees = {"basic_economy": 75, "main_cabin": 75, "premium_economy": 75, "business": 0, "first": 0}
+        change_fee = voluntary_fees.get(original_fare_class, 75)
 
     # Partial rebook: validate the specific flight segment exists
     if flight_number:

--- a/tests/unit/airline/test_agent_yaml_enums.py
+++ b/tests/unit/airline/test_agent_yaml_enums.py
@@ -1,0 +1,105 @@
+"""Drift test: YAML tool `enum:` lists must match the Pydantic StrEnums.
+
+For every param in `configs/agents/airline_agent.yaml` whose Pydantic field is
+backed by a StrEnum, the YAML must declare an `enum:` with the same values. And
+vice versa: any YAML `enum:` must correspond to a real StrEnum on the Pydantic
+side. This catches the case where someone adds a value to a StrEnum but forgets
+to update the YAML (or removes one only from Pydantic).
+"""
+
+import types
+import typing
+from enum import StrEnum
+from pathlib import Path
+
+import pytest
+import yaml
+
+from eva.assistant.tools import airline_params
+
+AGENT_YAML = Path(__file__).parents[3] / "configs" / "agents" / "airline_agent.yaml"
+
+
+def _tool_name_to_params_class(tool_name: str) -> type | None:
+    """Convert 'get_reservation' → GetReservationParams class on airline_params."""
+    pascal = "".join(part.capitalize() for part in tool_name.split("_"))
+    return getattr(airline_params, pascal + "Params", None)
+
+
+def _extract_str_enum(annotation: object) -> type[StrEnum] | None:
+    """Return the StrEnum type from an annotation like `FareClass` or `FareClass | None`."""
+    if isinstance(annotation, type) and issubclass(annotation, StrEnum):
+        return annotation
+    # Unwrap Union / Optional / PEP 604 `X | None`
+    if typing.get_origin(annotation) in (typing.Union, types.UnionType):
+        for arg in typing.get_args(annotation):
+            enum_cls = _extract_str_enum(arg)
+            if enum_cls is not None:
+                return enum_cls
+    return None
+
+
+@pytest.fixture(scope="module")
+def agent_yaml() -> dict:
+    with open(AGENT_YAML, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _iter_tool_params(agent_yaml: dict):
+    """Yield (tool_name, param_dict) for every param (required + optional) in the YAML."""
+    for tool in agent_yaml.get("tools", []):
+        tool_name = tool["name"]
+        for param in tool.get("required_parameters", []) + tool.get("optional_parameters", []):
+            if isinstance(param, dict):
+                yield tool_name, param
+
+
+def test_yaml_enum_values_match_pydantic_str_enums(agent_yaml):
+    """Every YAML `enum:` must match the values of the underlying Pydantic StrEnum."""
+    mismatches = []
+    for tool_name, param in _iter_tool_params(agent_yaml):
+        yaml_enum = param.get("enum")
+        if yaml_enum is None:
+            continue
+
+        params_cls = _tool_name_to_params_class(tool_name)
+        assert params_cls is not None, f"No *Params class found for tool '{tool_name}'"
+
+        field = params_cls.model_fields.get(param["name"])
+        assert field is not None, f"Param '{param['name']}' not found on {params_cls.__name__}"
+
+        enum_cls = _extract_str_enum(field.annotation)
+        if enum_cls is None:
+            mismatches.append(
+                f"{tool_name}.{param['name']}: YAML declares enum but Pydantic field is not a StrEnum "
+                f"(annotation: {field.annotation})"
+            )
+            continue
+
+        expected = {v.value for v in enum_cls}
+        actual = set(yaml_enum)
+        if expected != actual:
+            mismatches.append(
+                f"{tool_name}.{param['name']}: YAML={sorted(actual)} vs {enum_cls.__name__}={sorted(expected)}"
+            )
+
+    assert not mismatches, "YAML enum drift from Pydantic StrEnums:\n  " + "\n  ".join(mismatches)
+
+
+def test_pydantic_str_enum_fields_have_yaml_enum(agent_yaml):
+    """Every Pydantic field backed by a StrEnum must have a corresponding `enum:` in the YAML."""
+    missing = []
+    for tool_name, param in _iter_tool_params(agent_yaml):
+        params_cls = _tool_name_to_params_class(tool_name)
+        if params_cls is None:
+            continue
+        field = params_cls.model_fields.get(param["name"])
+        if field is None:
+            continue
+        enum_cls = _extract_str_enum(field.annotation)
+        if enum_cls is not None and param.get("enum") is None:
+            missing.append(
+                f"{tool_name}.{param['name']}: Pydantic uses {enum_cls.__name__} but YAML has no `enum:` list"
+            )
+
+    assert not missing, "Pydantic StrEnums not reflected in YAML:\n  " + "\n  ".join(missing)

--- a/tests/unit/airline/test_tools.py
+++ b/tests/unit/airline/test_tools.py
@@ -1078,6 +1078,33 @@ def test_get_reservation_not_found(sample_db):
     assert "XXXXXX" in result["message"]
 
 
+def test_get_reservation_enriches_with_flight_details(sample_db):
+    """Bookings returned from get_reservation are enriched with flight details from the journeys table."""
+    params = {"confirmation_number": "ABC123", "last_name": "Doe"}
+    result = get_reservation(params, sample_db, call_index=1)
+
+    assert result["status"] == "success"
+    bookings_by_journey = {b["journey_id"]: b for b in result["reservation"]["bookings"]}
+
+    cancelled = bookings_by_journey["FL_SW100_20260320"]
+    cancelled_seg = cancelled["segments"][0]
+    assert cancelled_seg["origin"] == "LAX"
+    assert cancelled_seg["destination"] == "JFK"
+    assert cancelled_seg["scheduled_departure"] == "10:00"
+    assert cancelled_seg["scheduled_arrival"] == "18:00"
+
+    confirmed = bookings_by_journey["FL_SW200_20260320"]
+    confirmed_seg = confirmed["segments"][0]
+    assert confirmed_seg["origin"] == "LAX"
+    assert confirmed_seg["destination"] == "JFK"
+    assert confirmed_seg["scheduled_departure"] == "14:00"
+    assert confirmed_seg["scheduled_arrival"] == "22:00"
+
+    # Enrichment must not mutate the underlying DB
+    db_seg = sample_db["reservations"]["ABC123"]["bookings"][1]["segments"][0]
+    assert "scheduled_departure" not in db_seg
+
+
 def test_get_flight_status_success(sample_db):
     """Test successful flight status lookup."""
     params = {"flight_number": "SW200", "flight_date": "2026-03-20"}

--- a/tests/unit/airline/test_tools.py
+++ b/tests/unit/airline/test_tools.py
@@ -1248,6 +1248,109 @@ def test_rebook_flight_irrops_no_fees(sample_db):
     assert result["cost_summary"]["fee_waived"] is True
 
 
+def test_rebook_flight_voluntary_basic_economy_fee(sample_db):
+    """Voluntary rebook on a Basic Economy booking: flat $75 (not the same-day $199 penalty)."""
+    db = copy.deepcopy(sample_db)
+    # Flip the cancelled booking's fare_class to basic_economy for this test.
+    db["reservations"]["ABC123"]["bookings"][0]["fare_class"] = "basic_economy"
+    params = {
+        "confirmation_number": "ABC123",
+        "journey_id": "FL_SW100_20260320",
+        "new_journey_id": "FL_SW200_20260320",
+        "rebooking_type": "voluntary",
+        "waive_change_fee": False,
+    }
+    result = rebook_flight(params, db, call_index=1)
+
+    assert result["status"] == "success"
+    assert result["cost_summary"]["change_fee"] == 75
+
+
+def test_rebook_flight_same_day_basic_economy_penalty_fee(sample_db):
+    """Same-day rebook on a Basic Economy booking: $199 penalty."""
+    db = copy.deepcopy(sample_db)
+    db["reservations"]["ABC123"]["bookings"][0]["fare_class"] = "basic_economy"
+    params = {
+        "confirmation_number": "ABC123",
+        "journey_id": "FL_SW100_20260320",
+        "new_journey_id": "FL_SW200_20260320",
+        "rebooking_type": "same_day",
+        "waive_change_fee": False,
+    }
+    result = rebook_flight(params, db, call_index=1)
+
+    assert result["status"] == "success"
+    assert result["cost_summary"]["change_fee"] == 199
+
+
+def test_rebook_flight_same_day_main_cabin_standard_fee(sample_db):
+    """Same-day rebook on Main Cabin: standard $75 fee (no penalty)."""
+    db = copy.deepcopy(sample_db)
+    params = {
+        "confirmation_number": "ABC123",
+        "journey_id": "FL_SW100_20260320",
+        "new_journey_id": "FL_SW200_20260320",
+        "rebooking_type": "same_day",
+        "waive_change_fee": False,
+    }
+    result = rebook_flight(params, db, call_index=1)
+
+    assert result["status"] == "success"
+    assert result["cost_summary"]["change_fee"] == 75
+
+
+def test_rebook_flight_same_day_business_class_fee(sample_db):
+    """Same-day rebook on Business Class: $75 (Business pays for same-day, unlike voluntary)."""
+    db = copy.deepcopy(sample_db)
+    db["reservations"]["ABC123"]["bookings"][0]["fare_class"] = "business"
+    params = {
+        "confirmation_number": "ABC123",
+        "journey_id": "FL_SW100_20260320",
+        "new_journey_id": "FL_SW200_20260320",
+        "rebooking_type": "same_day",
+        "waive_change_fee": False,
+    }
+    result = rebook_flight(params, db, call_index=1)
+
+    assert result["status"] == "success"
+    assert result["cost_summary"]["change_fee"] == 75
+
+
+def test_rebook_flight_voluntary_business_class_no_fee(sample_db):
+    """Voluntary rebook on Business Class: $0 (free for Business/First in advance changes)."""
+    db = copy.deepcopy(sample_db)
+    db["reservations"]["ABC123"]["bookings"][0]["fare_class"] = "business"
+    params = {
+        "confirmation_number": "ABC123",
+        "journey_id": "FL_SW100_20260320",
+        "new_journey_id": "FL_SW200_20260320",
+        "rebooking_type": "voluntary",
+        "waive_change_fee": False,
+    }
+    result = rebook_flight(params, db, call_index=1)
+
+    assert result["status"] == "success"
+    assert result["cost_summary"]["change_fee"] == 0
+
+
+def test_rebook_flight_same_day_basic_economy_waived_for_elite(sample_db):
+    """Gold/Platinum waiver zeros the same-day penalty for Basic Economy."""
+    db = copy.deepcopy(sample_db)
+    db["reservations"]["ABC123"]["bookings"][0]["fare_class"] = "basic_economy"
+    params = {
+        "confirmation_number": "ABC123",
+        "journey_id": "FL_SW100_20260320",
+        "new_journey_id": "FL_SW200_20260320",
+        "rebooking_type": "same_day",
+        "waive_change_fee": True,
+    }
+    result = rebook_flight(params, db, call_index=1)
+
+    assert result["status"] == "success"
+    assert result["cost_summary"]["change_fee"] == 0
+    assert result["cost_summary"]["fee_waived"] is True
+
+
 def test_rebook_flight_reservation_not_found(sample_db):
     """Test rebooking with invalid reservation."""
     params = {


### PR DESCRIPTION
## Summary

- Enrich `get_reservation` responses with per-segment origin/destination/scheduled times from the journeys table (read-time only, no DB impact).
- Promote enum-valued tool params to proper JSON Schema `enum:` fields so the LLM gets a hard constraint; add a two-way drift test between the YAML and the Pydantic StrEnums.
- Require caller confirmation before invoking `transfer_to_agent`.
- Make standby policy consistent: free for all fare classes; drop the unexercised Basic Economy exclusion and the now-meaningless elite standby-fee waivers.
- Fix `same_day` vs `voluntary` rebook fees: Basic Economy now pays $199 same-day / $75 voluntary; Business/First pay $75 same-day / $0 voluntary. Clarify in instructions when to pick each.

## Test plan

- [x] `pytest tests/unit/airline/` — 110 passed
- [x] New drift test catches YAML↔Pydantic enum mismatches (verified by intentionally leaving one out)
- [x] Verified no `expected_scenario_db` impact: `change_fee` is response-only; no existing scenario touches the changed code paths (Business/First same-day, Basic Economy rebook)