### PR TITLE
Pronunciation Metric

### DIFF
--- a/configs/prompts/judge.yaml
+++ b/configs/prompts/judge.yaml
@@ -1147,98 +1147,84 @@ judge:
 
   pronunciation:
     user_prompt: |
-        You are evaluating the pronunciation quality of a voice agent.
-        Listen to the audio and assess each turn as a typical customer of a professional voice
-        agent would — not as a linguist.
+        You are evaluating the PHONETIC pronunciation quality of a voice agent.
+        Listen to the audio and assess each turn on acoustic-phonetic grounds only.
 
-        Your job is to evaluate HOW words are spoken, not whether the correct words were spoken.
-        Word-level accuracy is a separate concern — focus entirely on pronunciation.
+        This metric evaluates two narrow things: whether individual phonemes within words are
+        produced correctly, and whether lexical stress falls on the right syllable. It does
+        NOT evaluate the content of what was said, the choice of words, accent or regional
+        variation, or whether entities such as dates, currencies, acronyms, or confirmation
+        codes were rendered accurately. A separate fidelity metric handles content accuracy.
 
-        The reference standard is General American English (e.g. a national US news anchor).
-        Non-American accents or inconsistent accent shifts are errors.
+        Use the dictionary pronunciation of General American English as your reference.
 
-        ## Intended Turns
-        {intended_turns_formatted}
+        ## Turns to Evaluate
+        The assistant audio contains the following turns, in order of appearance:
+        {turn_ids_formatted}
+
+        Segment the audio yourself by assistant utterance. Produce one rating per turn,
+        and assign the matching turn_id from the list above in the order the turns appear.
 
         ## Error Dimensions
 
-        For each turn, evaluate all seven dimensions. Every dimension must have an evidence field
+        Evaluate both dimensions for every turn. Every dimension must have an evidence field
         — even when clean, briefly explain why no issue was found.
 
-        - **non_standard_accent**: accent outside General American English, or an accent that
-          shifts inconsistently across words.
-        - **bad_stress**: stress falls on the wrong syllable within a multi-syllable word.
-        - **bad_sound**: one or more sounds within a word are pronounced incorrectly.
-        - **bad_date**: a date is read in a non-fluent or unnatural manner.
-        - **bad_currency**: a currency value is read in a non-fluent or unnatural manner.
-        - **bad_acronym**: an acronym is not spelled out letter-by-letter when it should be, or
-          is incorrectly blended into a word.
-        - **other_special_words**: abbreviations, URLs, or other non-standard words are
-          mispronounced.
+        - **bad_stress**: lexical stress falls on the wrong syllable of a multi-syllable word,
+          changing the word's natural prosody. Classic example: "REcord" (noun) produced as
+          "reCORD" (verb) when used as a noun. Flag only when the mis-stress is acoustically
+          clear and audible; do not flag emphasis-for-meaning or sentence-level prosody.
+
+        - **bad_sound**: one or more individual phonemes within a word are mispronounced —
+          substituted, omitted, added, or distorted — relative to the dictionary pronunciation.
+          Example: "ski-zors" instead of "si-zors" for "scissors". This is about the acoustic
+          realisation of phonemes, not about whether the right word was spoken.
 
         ## What NOT to penalise
-        - Whether the agent said the correct words (that is a separate fidelity metric)
-        - Turns that were interrupted or cut off — see interruption tags below
-
-        ### Interruption Tags
-        {interruption_tags_reference}
-
-        Do NOT penalise for pronunciation in turns that were cut off or interrupted.
+        - Whether the agent said the correct words or rendered entities (dates, currencies,
+          acronyms, codes) accurately — those are fidelity concerns, not pronunciation.
+        - Rendering choices for numbers, dates, or amounts — e.g. "fifteen dollars" vs "one
+          five dollars" is a rendering-style decision, not a pronunciation error.
+        - Accent or regional variation — do not flag non-American vowels or rhoticity.
+        - TTS artifacts unrelated to phonetic production (background noise, clicks, volume).
+        - Turns that were interrupted or cut off.
 
         ## Rating Scale (per turn)
         Rate each turn from the perspective of a typical customer interacting with a professional
-        voice agent. The bar for a passing rating is high — only native-quality pronunciation passes.
+        voice agent. Only clearly unacceptable pronunciation fails.
 
-        - **1** (Great): The pronunciation of every word — including sounds and the stress
-          placed on specific syllables — is great quality. There may be very minor errors but
-          overall, the turn would meet or exceed a typical customer's expectations. All
-          pronunciations are in line with those expected from a native speaker of General
-          American English.
+        - **1** (Acceptable or Great): The meaning is fully interpretable and the agent sounds
+          competent. This covers both:
+          • *Great* — pronunciation of every word, including sounds and syllable stress, is
+            in line with a native speaker of General American English. Very minor errors only.
+          • *Acceptable* — one or more pronunciation errors are present, but the turn still
+            meets a typical customer's expectations (e.g. a non-standard accent that doesn't
+            impair comprehension).
 
-        - **0** (Not great): Pronunciation has one or more noticeable errors in word sounds
-          or syllable stress. This covers both:
-          • *Acceptable* — errors present but meaning is fully interpretable and the agent
-            still sounds competent (e.g. a non-standard accent that doesn't impair comprehension).
-          • *Unacceptable* — errors that have a high negative impact on comprehension or the
-            listening experience (e.g. clearly wrong word stress, badly mispronounced special
-            words, or a non-standard accent severe enough to impair comprehension).
+        - **0** (Unacceptable): Pronunciation errors that have a high negative impact on
+          comprehension or the listening experience and would not meet a typical customer's
+          expectations. Examples include clearly wrong word stress (e.g. "REcord" when "reCORD"
+          is intended), badly mispronounced special words such as dates, currencies, or
+          acronyms, or a non-standard accent severe enough to impair comprehension.
 
         ## Response Format
-        Respond with a JSON object. The evidence field is REQUIRED for every dimension in every
-        turn — cite specific words or phrases heard if flagged, or briefly explain why clean if not.
+        Respond with a JSON object. For each turn you MUST provide a `transcript` field
+        containing your own transcription of the audio for that turn — do not skip or leave
+        it empty. The `evidence` field is REQUIRED for every dimension in every turn — cite
+        specific words or phrases heard if flagged, or briefly explain why clean if not.
         {{
           "turns": [
             {{
-              "turn_id": <int: the turn number from the Intended Turns>,
-              "transcript": "<string: your transcription of what was spoken in this turn>",
+              "turn_id": <int: turn_id from the Turns to Evaluate list above>,
+              "transcript": "<string: REQUIRED — your transcription of the audio for this turn, based only on what you heard>",
               "errors": {{
-                "non_standard_accent": {{
-                  "flagged": <bool>,
-                  "evidence": "<string: REQUIRED — cite the specific words that sounded non-standard, or explain why accent is clean>"
-                }},
                 "bad_stress": {{
                   "flagged": <bool>,
-                  "evidence": "<string: REQUIRED — cite the mispronounced word and which syllable was stressed, or confirm stress was correct>"
+                  "evidence": "<string: REQUIRED — cite the word and which syllable was stressed vs which should have been, or confirm stress was correct>"
                 }},
                 "bad_sound": {{
                   "flagged": <bool>,
-                  "evidence": "<string: REQUIRED — cite word and what was heard vs expected, or confirm sounds were correct>"
-                }},
-                "bad_date": {{
-                  "flagged": <bool>,
-                  "evidence": "<string: REQUIRED — cite how the date was spoken and what was expected, or confirm no dates present / dates read correctly>"
-                }},
-                "bad_currency": {{
-                  "flagged": <bool>,
-                  "evidence": "<string: REQUIRED — cite how the amount was spoken and what was expected, or confirm no currency present / currency read correctly>"
-                }},
-                "bad_acronym": {{
-                  "flagged": <bool>,
-                  "evidence": "<string: REQUIRED — cite the acronym and how it was pronounced, or confirm no acronyms present / acronyms read correctly>"
-                }},
-                "other_special_words": {{
-                  "flagged": <bool>,
-                  "evidence": "<string: REQUIRED — cite the word and what was heard vs expected, or confirm no special words present / all read correctly>"
+                  "evidence": "<string: REQUIRED — cite the word and which phoneme was produced incorrectly (what was heard vs the dictionary pronunciation), or confirm sounds were correct>"
                 }}
               }},
               "explanation": "<string: 1-3 sentences summarising the overall pronunciation quality of this turn>",

--- a/configs/prompts/judge.yaml
+++ b/configs/prompts/judge.yaml
@@ -1147,72 +1147,126 @@ judge:
 
   pronunciation:
     user_prompt: |
-        You are a phonetics expert evaluating the pronunciation quality of a voice agent's speech.
-        You will listen to an audio recording and assess how naturally and correctly each turn is pronounced.
+        You are evaluating the pronunciation quality of a voice agent.
+        Listen to the audio and assess each turn as a typical customer of a professional voice
+        agent would — not as a linguist.
 
         Your job is to evaluate HOW words are spoken, not whether the correct words were spoken.
-        Word-level accuracy is a separate concern — focus entirely on phonetic quality.
+        Word-level accuracy is a separate concern — focus entirely on pronunciation.
+
+        The reference standard is General American English (e.g. a national US news anchor).
+        Non-American accents or inconsistent accent shifts are errors.
 
         ## Intended Turns
         {intended_turns_formatted}
 
-        ## Evaluation Criteria
+        ## Error Dimensions
 
-        For each turn, assess the following dimensions:
+        For each turn, evaluate all seven dimensions. Every dimension must have an evidence field
+        — even when clean, briefly explain why no issue was found.
 
-        **Vowel quality**
-        Are vowel sounds close to standard American English targets? Centralised, reduced, or
-        indistinct vowels (e.g. every vowel sounding like a schwa) indicate poor phoneme realisation.
+        **non_standard_accent**
+        The agent sounds like it has an accent outside General American English, or the accent
+        shifts inconsistently across words.
+        Example: "i pahked the cah" (non-standard) vs "i parked the car" (correct).
 
-        **Stress contrast**
-        Do stressed syllables sound noticeably longer and louder than unstressed syllables?
-        Natural English has roughly 1.5–2.5× longer stressed vowels. Flat, metronomic delivery
-        where all syllables are equal length is a hallmark of robotic TTS.
+        **bad_stress**
+        Within a multi-syllable word, stress falls on the wrong syllable.
+        Example: "i see your REcord" (correct, noun) vs "i see your reCORD" (incorrect).
 
-        **Consonant articulation**
-        Are stops, fricatives, and affricates cleanly produced? Listen for:
-        - Stops (p, t, k, b, d, g): appropriate burst/release
-        - Fricatives (s, z, f, v, sh): clear frication, not muffled
-        - Word-final consonants not swallowed or over-articulated
+        **bad_sound**
+        One or more sounds within a word are pronounced incorrectly.
+        Example: "ski-zors" (incorrect) vs "si-zers" for "scissors" (correct).
 
-        **Connected speech**
-        Does the speech flow with natural coarticulation — smooth transitions between sounds —
-        or do phonemes sound isolated and clipped as if each were produced separately?
+        **bad_date**
+        A date is read in a non-fluent or unnatural manner.
+        Example: "ten slash three slash two zero two five" (incorrect) vs
+        "October third, twenty-twenty-five" (correct) for "10/3/2025".
 
-        **Overall naturalness**
-        Does it sound like fluent human speech, or does it have the flat, over-precise, or
-        mechanical quality typical of poor TTS?
+        **bad_currency**
+        A currency value is read in a non-fluent or unnatural manner.
+        Example: "four point five zero dollars" (incorrect) vs
+        "four dollars and fifty cents" (correct) for "$4.50".
+
+        **bad_acronym**
+        An acronym is not spelled out letter-by-letter when it should be, or is incorrectly
+        blended into a word.
+        Example: "sesv" (incorrect) vs "see-es-vee" (correct) for "CSV".
+
+        **other_special_words**
+        Abbreviations, URLs, or other non-standard words are mispronounced.
+        Example: "123 hillside doctor" (incorrect) vs "123 hillside drive" (correct) for "123 hillside dr."
 
         ## What NOT to penalise
-        - Different words than intended (word accuracy is not this metric's concern)
-        - Slight regional accent variation that does not impair naturalness
+        - Whether the agent said the correct words (that is a separate fidelity metric)
         - Turns that were interrupted or cut off — see interruption tags below
 
         ### Interruption Tags
         {interruption_tags_reference}
 
-        Do NOT penalise for pronunciation in turns that were cut off by an interruption.
+        Do NOT penalise for pronunciation in turns that were cut off or interrupted.
 
         ## Rating Scale (per turn)
-        - **3** (Natural): Vowels on-target, clear stress contrast, consonants well-articulated,
-          connected speech sounds fluid. Listener would not notice anything unusual.
-        - **2** (Mostly natural): One or two noticeable issues — a mispronounced phoneme, weak
-          stress contrast, or slightly mechanical quality — but the turn is largely intelligible
-          and natural-sounding.
-        - **1** (Unnatural): Clear pronunciation problems that impair naturalness — consistently
-          wrong vowel quality, flat stress throughout, clipped or distorted consonants, or
-          obviously robotic delivery.
+        Rate each turn from the perspective of a typical customer interacting with a professional
+        voice agent.
+
+        - **3** (Great): Pronunciation is natural and native-sounding throughout. All words —
+          including dates, currencies, acronyms, and abbreviations — are spoken as a native
+          General American English speaker would say them. Any errors are so minor they would
+          not be noticed.
+
+        - **2** (Acceptable): There are one or more pronunciation errors, but the turn is still
+          acceptable quality. The meaning is fully interpretable and the agent still sounds
+          competent. The errors are noticeable to a careful listener but do not impair
+          comprehension or the overall listening experience.
+
+        - **1** (Unacceptable): Pronunciation errors that a typical customer would notice and
+          that undermine the credibility of the agent. This includes clearly wrong word stress
+          (e.g. "REcord" when "reCORD" is intended), badly mispronounced special words such as
+          dates, currencies, or acronyms, or a non-standard accent severe enough to impair
+          comprehension.
 
         ## Response Format
+        Respond with a JSON object. The evidence field is REQUIRED for every dimension in every
+        turn — cite specific words or phrases heard if flagged, or briefly explain why clean if not.
         {{
           "turns": [
             {{
               "turn_id": <int: the turn number from the Intended Turns>,
               "transcript": "<string: your transcription of what was spoken in this turn>",
-              "explanation": "<string: 1-3 sentences on what you hear phonetically, citing specific examples of correct or incorrect pronunciation>",
+              "errors": {{
+                "non_standard_accent": {{
+                  "flagged": <bool>,
+                  "evidence": "<string: REQUIRED — cite the specific words that sounded non-standard, or explain why accent is clean>"
+                }},
+                "bad_stress": {{
+                  "flagged": <bool>,
+                  "evidence": "<string: REQUIRED — cite the mispronounced word and which syllable was stressed, or confirm stress was correct>"
+                }},
+                "bad_sound": {{
+                  "flagged": <bool>,
+                  "evidence": "<string: REQUIRED — cite word and what was heard vs expected, or confirm sounds were correct>"
+                }},
+                "bad_date": {{
+                  "flagged": <bool>,
+                  "evidence": "<string: REQUIRED — cite how the date was spoken and what was expected, or confirm no dates present / dates read correctly>"
+                }},
+                "bad_currency": {{
+                  "flagged": <bool>,
+                  "evidence": "<string: REQUIRED — cite how the amount was spoken and what was expected, or confirm no currency present / currency read correctly>"
+                }},
+                "bad_acronym": {{
+                  "flagged": <bool>,
+                  "evidence": "<string: REQUIRED — cite the acronym and how it was pronounced, or confirm no acronyms present / acronyms read correctly>"
+                }},
+                "other_special_words": {{
+                  "flagged": <bool>,
+                  "evidence": "<string: REQUIRED — cite the word and what was heard vs expected, or confirm no special words present / all read correctly>"
+                }}
+              }},
+              "explanation": "<string: 1-3 sentences summarising the overall pronunciation quality of this turn>",
               "rating": <1, 2, or 3>
             }}
           ],
           "explanation": "<string: overall summary of pronunciation quality across all turns>"
         }}
-      ]

--- a/configs/prompts/judge.yaml
+++ b/configs/prompts/judge.yaml
@@ -1165,37 +1165,16 @@ judge:
         For each turn, evaluate all seven dimensions. Every dimension must have an evidence field
         — even when clean, briefly explain why no issue was found.
 
-        **non_standard_accent**
-        The agent sounds like it has an accent outside General American English, or the accent
-        shifts inconsistently across words.
-        Example: "i pahked the cah" (non-standard) vs "i parked the car" (correct).
-
-        **bad_stress**
-        Within a multi-syllable word, stress falls on the wrong syllable.
-        Example: "i see your REcord" (correct, noun) vs "i see your reCORD" (incorrect).
-
-        **bad_sound**
-        One or more sounds within a word are pronounced incorrectly.
-        Example: "ski-zors" (incorrect) vs "si-zers" for "scissors" (correct).
-
-        **bad_date**
-        A date is read in a non-fluent or unnatural manner.
-        Example: "ten slash three slash two zero two five" (incorrect) vs
-        "October third, twenty-twenty-five" (correct) for "10/3/2025".
-
-        **bad_currency**
-        A currency value is read in a non-fluent or unnatural manner.
-        Example: "four point five zero dollars" (incorrect) vs
-        "four dollars and fifty cents" (correct) for "$4.50".
-
-        **bad_acronym**
-        An acronym is not spelled out letter-by-letter when it should be, or is incorrectly
-        blended into a word.
-        Example: "sesv" (incorrect) vs "see-es-vee" (correct) for "CSV".
-
-        **other_special_words**
-        Abbreviations, URLs, or other non-standard words are mispronounced.
-        Example: "123 hillside doctor" (incorrect) vs "123 hillside drive" (correct) for "123 hillside dr."
+        - **non_standard_accent**: accent outside General American English, or an accent that
+          shifts inconsistently across words.
+        - **bad_stress**: stress falls on the wrong syllable within a multi-syllable word.
+        - **bad_sound**: one or more sounds within a word are pronounced incorrectly.
+        - **bad_date**: a date is read in a non-fluent or unnatural manner.
+        - **bad_currency**: a currency value is read in a non-fluent or unnatural manner.
+        - **bad_acronym**: an acronym is not spelled out letter-by-letter when it should be, or
+          is incorrectly blended into a word.
+        - **other_special_words**: abbreviations, URLs, or other non-standard words are
+          mispronounced.
 
         ## What NOT to penalise
         - Whether the agent said the correct words (that is a separate fidelity metric)
@@ -1208,23 +1187,21 @@ judge:
 
         ## Rating Scale (per turn)
         Rate each turn from the perspective of a typical customer interacting with a professional
-        voice agent.
+        voice agent. The bar for a passing rating is high — only native-quality pronunciation passes.
 
-        - **3** (Great): Pronunciation is natural and native-sounding throughout. All words —
-          including dates, currencies, acronyms, and abbreviations — are spoken as a native
-          General American English speaker would say them. Any errors are so minor they would
-          not be noticed.
+        - **1** (Great): The pronunciation of every word — including sounds and the stress
+          placed on specific syllables — is great quality. There may be very minor errors but
+          overall, the turn would meet or exceed a typical customer's expectations. All
+          pronunciations are in line with those expected from a native speaker of General
+          American English.
 
-        - **2** (Acceptable): There are one or more pronunciation errors, but the turn is still
-          acceptable quality. The meaning is fully interpretable and the agent still sounds
-          competent. The errors are noticeable to a careful listener but do not impair
-          comprehension or the overall listening experience.
-
-        - **1** (Unacceptable): Pronunciation errors that a typical customer would notice and
-          that undermine the credibility of the agent. This includes clearly wrong word stress
-          (e.g. "REcord" when "reCORD" is intended), badly mispronounced special words such as
-          dates, currencies, or acronyms, or a non-standard accent severe enough to impair
-          comprehension.
+        - **0** (Not great): Pronunciation has one or more noticeable errors in word sounds
+          or syllable stress. This covers both:
+          • *Acceptable* — errors present but meaning is fully interpretable and the agent
+            still sounds competent (e.g. a non-standard accent that doesn't impair comprehension).
+          • *Unacceptable* — errors that have a high negative impact on comprehension or the
+            listening experience (e.g. clearly wrong word stress, badly mispronounced special
+            words, or a non-standard accent severe enough to impair comprehension).
 
         ## Response Format
         Respond with a JSON object. The evidence field is REQUIRED for every dimension in every
@@ -1265,7 +1242,7 @@ judge:
                 }}
               }},
               "explanation": "<string: 1-3 sentences summarising the overall pronunciation quality of this turn>",
-              "rating": <1, 2, or 3>
+              "rating": <0 or 1>
             }}
           ],
           "explanation": "<string: overall summary of pronunciation quality across all turns>"

--- a/configs/prompts/judge.yaml
+++ b/configs/prompts/judge.yaml
@@ -1156,14 +1156,13 @@ judge:
         variation, or whether entities such as dates, currencies, acronyms, or confirmation
         codes were rendered accurately. A separate fidelity metric handles content accuracy.
 
-        Use the dictionary pronunciation of General American English as your reference.
-
         ## Turns to Evaluate
         The assistant audio contains the following turns, in order of appearance:
         {turn_ids_formatted}
 
-        Segment the audio yourself by assistant utterance. Produce one rating per turn,
-        and assign the matching turn_id from the list above in the order the turns appear.
+        The list above contains only turn identifiers — no content. Transcribe each turn
+        from the audio alone. Produce one rating per turn, and assign the matching turn_id
+        from the list above in the order the turns appear in the audio.
 
         ## Error Dimensions
 

--- a/configs/prompts/judge.yaml
+++ b/configs/prompts/judge.yaml
@@ -1144,4 +1144,75 @@ judge:
           ],
           "summary": "<1-2 sentence summary for this turn>"
       }}
+
+  pronunciation:
+    user_prompt: |
+        You are a phonetics expert evaluating the pronunciation quality of a voice agent's speech.
+        You will listen to an audio recording and assess how naturally and correctly each turn is pronounced.
+
+        Your job is to evaluate HOW words are spoken, not whether the correct words were spoken.
+        Word-level accuracy is a separate concern — focus entirely on phonetic quality.
+
+        ## Intended Turns
+        {intended_turns_formatted}
+
+        ## Evaluation Criteria
+
+        For each turn, assess the following dimensions:
+
+        **Vowel quality**
+        Are vowel sounds close to standard American English targets? Centralised, reduced, or
+        indistinct vowels (e.g. every vowel sounding like a schwa) indicate poor phoneme realisation.
+
+        **Stress contrast**
+        Do stressed syllables sound noticeably longer and louder than unstressed syllables?
+        Natural English has roughly 1.5–2.5× longer stressed vowels. Flat, metronomic delivery
+        where all syllables are equal length is a hallmark of robotic TTS.
+
+        **Consonant articulation**
+        Are stops, fricatives, and affricates cleanly produced? Listen for:
+        - Stops (p, t, k, b, d, g): appropriate burst/release
+        - Fricatives (s, z, f, v, sh): clear frication, not muffled
+        - Word-final consonants not swallowed or over-articulated
+
+        **Connected speech**
+        Does the speech flow with natural coarticulation — smooth transitions between sounds —
+        or do phonemes sound isolated and clipped as if each were produced separately?
+
+        **Overall naturalness**
+        Does it sound like fluent human speech, or does it have the flat, over-precise, or
+        mechanical quality typical of poor TTS?
+
+        ## What NOT to penalise
+        - Different words than intended (word accuracy is not this metric's concern)
+        - Slight regional accent variation that does not impair naturalness
+        - Turns that were interrupted or cut off — see interruption tags below
+
+        ### Interruption Tags
+        {interruption_tags_reference}
+
+        Do NOT penalise for pronunciation in turns that were cut off by an interruption.
+
+        ## Rating Scale (per turn)
+        - **3** (Natural): Vowels on-target, clear stress contrast, consonants well-articulated,
+          connected speech sounds fluid. Listener would not notice anything unusual.
+        - **2** (Mostly natural): One or two noticeable issues — a mispronounced phoneme, weak
+          stress contrast, or slightly mechanical quality — but the turn is largely intelligible
+          and natural-sounding.
+        - **1** (Unnatural): Clear pronunciation problems that impair naturalness — consistently
+          wrong vowel quality, flat stress throughout, clipped or distorted consonants, or
+          obviously robotic delivery.
+
+        ## Response Format
+        {{
+          "turns": [
+            {{
+              "turn_id": <int: the turn number from the Intended Turns>,
+              "transcript": "<string: your transcription of what was spoken in this turn>",
+              "explanation": "<string: 1-3 sentences on what you hear phonetically, citing specific examples of correct or incorrect pronunciation>",
+              "rating": <1, 2, or 3>
+            }}
+          ],
+          "explanation": "<string: overall summary of pronunciation quality across all turns>"
+        }}
       ]

--- a/src/eva/metrics/diagnostic/__init__.py
+++ b/src/eva/metrics/diagnostic/__init__.py
@@ -1,6 +1,7 @@
 """Debug metrics - diagnostic metrics for debugging model performance issues, not used in final evaluation scores."""
 
 from . import authentication_success  # noqa
+from . import pronunciation  # noqa
 from . import response_speed  # noqa
 from . import speakability  # noqa
 from . import stt_wer  # noqa
@@ -9,6 +10,7 @@ from . import transcription_accuracy_key_entities  # noqa
 
 __all__ = [
     "authentication_success",
+    "pronunciation",
     "response_speed",
     "speakability",
     "stt_wer",

--- a/src/eva/metrics/diagnostic/pronunciation.py
+++ b/src/eva/metrics/diagnostic/pronunciation.py
@@ -1,31 +1,46 @@
 """Pronunciation quality metric using audio + LLM judge (Gemini).
 
 Diagnostic metric for evaluating how naturally and correctly an agent's
-speech is pronounced — phoneme quality, stress contrast, connected speech.
+speech is pronounced, using the same error taxonomy as human annotators.
 """
 
+from typing import Any
+
+from eva.metrics.base import MetricContext
 from eva.metrics.registry import register_metric
 from eva.metrics.speech_fidelity_base import SpeechFidelityBaseMetric
+from eva.metrics.utils import aggregate_per_turn_scores, normalize_rating, resolve_turn_id
+from eva.models.results import MetricScore
+from eva.utils.json_utils import extract_and_load_json
+
+ERROR_DIMENSIONS = [
+    "non_standard_accent",
+    "bad_stress",
+    "bad_sound",
+    "bad_date",
+    "bad_currency",
+    "bad_acronym",
+    "other_special_words",
+]
 
 
 @register_metric
 class PronunciationMetric(SpeechFidelityBaseMetric):
     """Audio-based pronunciation quality metric for agent speech using Gemini.
 
-    Evaluates the phonetic naturalness of the agent's spoken audio:
-    - Vowel quality (are vowels hitting their phonemic targets?)
-    - Stress contrast (are stressed syllables noticeably longer/louder than unstressed?)
-    - Consonant articulation (stops, fricatives clearly produced?)
-    - Connected speech (natural coarticulation vs clipped, isolated phonemes)
-    - Overall delivery (fluid human-like speech vs flat/robotic TTS)
+    Evaluates pronunciation against the same seven error categories used by
+    human annotators:
+        non_standard_accent, bad_stress, bad_sound, bad_date,
+        bad_currency, bad_acronym, other_special_words
 
-    This is a diagnostic metric — it measures HOW words are spoken, not whether
-    the correct words were spoken (that is agent_speech_fidelity's job).
+    Each category is captured per turn with a flagged bool and evidence string,
+    mirroring the faithfulness/conversation_progression dimension pattern so
+    AI judgements can be directly compared to human annotations.
 
-    Rating scale per turn:
-        3 — Natural, fluent pronunciation throughout
-        2 — Mostly natural with noticeable but minor issues
-        1 — Clear pronunciation problems that impair naturalness
+    Rating scale per turn (matches human rubric):
+        3 — Great: natural General American English throughout
+        2 — Acceptable: errors present but meaning clear, agent still competent
+        1 — Unacceptable: errors a typical customer would notice
     Normalized: (rating - 1) / 2  →  0.0–1.0
     """
 
@@ -35,3 +50,135 @@ class PronunciationMetric(SpeechFidelityBaseMetric):
     role = "assistant"
     rating_scale = (1, 3)
     exclude_from_pass_at_k = True
+
+    async def compute(self, context: MetricContext) -> MetricScore:
+        """Compute pronunciation score, capturing per-turn error dimensions."""
+        try:
+            audio_segment = self.load_role_audio(context, self.role)
+            if audio_segment is None:
+                return MetricScore(
+                    name=self.name,
+                    score=0.0,
+                    normalized_score=0.0,
+                    error="No assistant audio file available",
+                )
+
+            intended_turns = self._get_intended_turns(context)
+            if not intended_turns:
+                return MetricScore(
+                    name=self.name,
+                    score=0.0,
+                    normalized_score=0.0,
+                    error="No intended assistant turns available",
+                )
+
+            num_turns = len(intended_turns)
+            audio_b64 = self.encode_audio_segment(audio_segment)
+            intended_turns_formatted = self._format_intended_turns(intended_turns)
+
+            prompt = self.get_judge_prompt(
+                prompt_key="user_prompt",
+                intended_turns_formatted=intended_turns_formatted,
+            )
+
+            messages = self.create_audio_message(audio_b64, prompt)
+            response_text, turns = await self._call_and_parse(
+                messages, context, audio_segment, prompt
+            )
+
+            if response_text is None:
+                return MetricScore(
+                    name=self.name,
+                    score=0.0,
+                    normalized_score=0.0,
+                    error="No response from judge",
+                )
+
+            if len(turns) != num_turns:
+                self.logger.warning(
+                    f"[{context.record_id}] Expected {num_turns} pronunciation ratings, got {len(turns)}"
+                )
+
+            tts_turn_ids = sorted(intended_turns.keys())
+            min_rating, max_rating = self.rating_scale
+            valid_ratings_range = list(range(min_rating, max_rating + 1))
+
+            per_turn_ratings: dict[int, int | None] = {}
+            per_turn_explanations: dict[int, str] = {}
+            per_turn_transcripts: dict[int, str] = {}
+            per_turn_normalized: dict[int, float] = {}
+            # Per-dimension data: {dim: {turn_id: {"flagged": bool, "evidence": str}}}
+            per_turn_errors: dict[int, dict[str, Any]] = {}
+
+            for item in turns:
+                turn_id = resolve_turn_id(item, tts_turn_ids, self.name)
+                if turn_id is None:
+                    continue
+
+                rating = item.get("rating")
+                if rating not in valid_ratings_range:
+                    self.logger.warning(
+                        f"[{context.record_id}] Invalid rating {rating} for turn {turn_id}"
+                    )
+                    per_turn_ratings[turn_id] = None
+                    per_turn_explanations[turn_id] = f"Invalid rating: {rating}"
+                    continue
+
+                per_turn_ratings[turn_id] = rating
+                per_turn_explanations[turn_id] = item.get("explanation", "")
+                per_turn_transcripts[turn_id] = item.get("transcript", "")
+                per_turn_normalized[turn_id] = normalize_rating(rating, min_rating, max_rating)
+
+                # Extract structured error dimensions
+                errors_raw = item.get("errors") or {}
+                per_turn_errors[turn_id] = {
+                    dim: {
+                        "flagged": bool(errors_raw.get(dim, {}).get("flagged", False)),
+                        "evidence": errors_raw.get(dim, {}).get("evidence", ""),
+                    }
+                    for dim in ERROR_DIMENSIONS
+                }
+
+            valid_ratings = [r for r in per_turn_ratings.values() if r is not None]
+            avg_rating = sum(valid_ratings) / len(valid_ratings) if valid_ratings else 0.0
+            aggregated_score = aggregate_per_turn_scores(
+                list(per_turn_normalized.values()), self.aggregation
+            )
+
+            # Build per-dimension flag summaries across all turns
+            per_dimension_summary: dict[str, Any] = {}
+            for dim in ERROR_DIMENSIONS:
+                flagged_turns = [
+                    tid
+                    for tid, errs in per_turn_errors.items()
+                    if errs.get(dim, {}).get("flagged", False)
+                ]
+                per_dimension_summary[dim] = {
+                    "flagged_turn_count": len(flagged_turns),
+                    "flagged_turn_ids": flagged_turns,
+                }
+
+            details: dict[str, Any] = {
+                "aggregation": self.aggregation,
+                "num_turns": num_turns,
+                "num_evaluated": len(valid_ratings),
+                "per_turn_ratings": per_turn_ratings,
+                "per_turn_normalized": per_turn_normalized,
+                "per_turn_explanations": per_turn_explanations,
+                "per_turn_transcripts": per_turn_transcripts,
+                "per_turn_errors": per_turn_errors,
+                "per_dimension_summary": per_dimension_summary,
+                "judge_prompt": prompt,
+                "judge_raw_response": response_text,
+            }
+
+            return MetricScore(
+                name=self.name,
+                score=round(avg_rating, 3),
+                normalized_score=round(aggregated_score, 3) if aggregated_score is not None else 0.0,
+                details=details,
+                error="Aggregation failed" if aggregated_score is None else None,
+            )
+
+        except Exception as e:
+            return self._handle_error(e, context)

--- a/src/eva/metrics/diagnostic/pronunciation.py
+++ b/src/eva/metrics/diagnostic/pronunciation.py
@@ -37,18 +37,18 @@ class PronunciationMetric(SpeechFidelityBaseMetric):
     mirroring the faithfulness/conversation_progression dimension pattern so
     AI judgements can be directly compared to human annotations.
 
-    Rating scale per turn (matches human rubric):
-        3 — Great: natural General American English throughout
-        2 — Acceptable: errors present but meaning clear, agent still competent
-        1 — Unacceptable: errors a typical customer would notice
-    Normalized: (rating - 1) / 2  →  0.0–1.0
+    Rating scale per turn (binary pass/fail — high bar):
+        1 — Great: native-quality General American English (human rubric: "Great")
+        0 — Not great: one or more noticeable errors in sounds or stress
+            (human rubric: "Acceptable" + "Unacceptable" collapsed)
+    Normalized: same as raw score (already 0–1).
     """
 
     name = "pronunciation"
     description = "Diagnostic metric: audio judge evaluation of agent pronunciation quality per turn"
     category = "diagnostic"
     role = "assistant"
-    rating_scale = (1, 3)
+    rating_scale = (0, 1)
     exclude_from_pass_at_k = True
 
     async def compute(self, context: MetricContext) -> MetricScore:

--- a/src/eva/metrics/diagnostic/pronunciation.py
+++ b/src/eva/metrics/diagnostic/pronunciation.py
@@ -11,7 +11,6 @@ from eva.metrics.registry import register_metric
 from eva.metrics.speech_fidelity_base import SpeechFidelityBaseMetric
 from eva.metrics.utils import aggregate_per_turn_scores, normalize_rating, resolve_turn_id
 from eva.models.results import MetricScore
-from eva.utils.json_utils import extract_and_load_json
 
 ERROR_DIMENSIONS = [
     "bad_stress",
@@ -76,9 +75,7 @@ class PronunciationMetric(SpeechFidelityBaseMetric):
             )
 
             messages = self.create_audio_message(audio_b64, prompt)
-            response_text, turns = await self._call_and_parse(
-                messages, context, audio_segment, prompt
-            )
+            response_text, turns = await self._call_and_parse(messages, context, audio_segment, prompt)
 
             if response_text is None:
                 return MetricScore(
@@ -111,9 +108,7 @@ class PronunciationMetric(SpeechFidelityBaseMetric):
 
                 rating = item.get("rating")
                 if rating not in valid_ratings_range:
-                    self.logger.warning(
-                        f"[{context.record_id}] Invalid rating {rating} for turn {turn_id}"
-                    )
+                    self.logger.warning(f"[{context.record_id}] Invalid rating {rating} for turn {turn_id}")
                     per_turn_ratings[turn_id] = None
                     per_turn_explanations[turn_id] = f"Invalid rating: {rating}"
                     continue
@@ -135,17 +130,13 @@ class PronunciationMetric(SpeechFidelityBaseMetric):
 
             valid_ratings = [r for r in per_turn_ratings.values() if r is not None]
             avg_rating = sum(valid_ratings) / len(valid_ratings) if valid_ratings else 0.0
-            aggregated_score = aggregate_per_turn_scores(
-                list(per_turn_normalized.values()), self.aggregation
-            )
+            aggregated_score = aggregate_per_turn_scores(list(per_turn_normalized.values()), self.aggregation)
 
             # Build per-dimension flag summaries across all turns
             per_dimension_summary: dict[str, Any] = {}
             for dim in ERROR_DIMENSIONS:
                 flagged_turns = [
-                    tid
-                    for tid, errs in per_turn_errors.items()
-                    if errs.get(dim, {}).get("flagged", False)
+                    tid for tid, errs in per_turn_errors.items() if errs.get(dim, {}).get("flagged", False)
                 ]
                 per_dimension_summary[dim] = {
                     "flagged_turn_count": len(flagged_turns),

--- a/src/eva/metrics/diagnostic/pronunciation.py
+++ b/src/eva/metrics/diagnostic/pronunciation.py
@@ -14,13 +14,8 @@ from eva.models.results import MetricScore
 from eva.utils.json_utils import extract_and_load_json
 
 ERROR_DIMENSIONS = [
-    "non_standard_accent",
     "bad_stress",
     "bad_sound",
-    "bad_date",
-    "bad_currency",
-    "bad_acronym",
-    "other_special_words",
 ]
 
 
@@ -28,19 +23,18 @@ ERROR_DIMENSIONS = [
 class PronunciationMetric(SpeechFidelityBaseMetric):
     """Audio-based pronunciation quality metric for agent speech using Gemini.
 
-    Evaluates pronunciation against the same seven error categories used by
-    human annotators:
-        non_standard_accent, bad_stress, bad_sound, bad_date,
-        bad_currency, bad_acronym, other_special_words
+    Scoped narrowly to phonetic production — does not overlap with
+    agent_speech_fidelity (which covers content/entity accuracy). Two dimensions:
+        bad_stress — lexical stress on the wrong syllable
+        bad_sound  — phoneme mispronounced (substituted/omitted/added/distorted)
 
-    Each category is captured per turn with a flagged bool and evidence string,
+    Each dimension is captured per turn with a flagged bool and evidence string,
     mirroring the faithfulness/conversation_progression dimension pattern so
     AI judgements can be directly compared to human annotations.
 
-    Rating scale per turn (binary pass/fail — high bar):
-        1 — Great: native-quality General American English (human rubric: "Great")
-        0 — Not great: one or more noticeable errors in sounds or stress
-            (human rubric: "Acceptable" + "Unacceptable" collapsed)
+    Rating scale per turn (binary pass/fail — low bar):
+        1 — Acceptable: phonetic production is competent
+        0 — Unacceptable: stress or phoneme errors that impair the turn
     Normalized: same as raw score (already 0–1).
     """
 
@@ -74,11 +68,11 @@ class PronunciationMetric(SpeechFidelityBaseMetric):
 
             num_turns = len(intended_turns)
             audio_b64 = self.encode_audio_segment(audio_segment)
-            intended_turns_formatted = self._format_intended_turns(intended_turns)
+            turn_ids_formatted = "\n".join(f"- turn_id {tid}" for tid in sorted(intended_turns.keys()))
 
             prompt = self.get_judge_prompt(
                 prompt_key="user_prompt",
-                intended_turns_formatted=intended_turns_formatted,
+                turn_ids_formatted=turn_ids_formatted,
             )
 
             messages = self.create_audio_message(audio_b64, prompt)

--- a/src/eva/metrics/diagnostic/pronunciation.py
+++ b/src/eva/metrics/diagnostic/pronunciation.py
@@ -1,0 +1,37 @@
+"""Pronunciation quality metric using audio + LLM judge (Gemini).
+
+Diagnostic metric for evaluating how naturally and correctly an agent's
+speech is pronounced — phoneme quality, stress contrast, connected speech.
+"""
+
+from eva.metrics.registry import register_metric
+from eva.metrics.speech_fidelity_base import SpeechFidelityBaseMetric
+
+
+@register_metric
+class PronunciationMetric(SpeechFidelityBaseMetric):
+    """Audio-based pronunciation quality metric for agent speech using Gemini.
+
+    Evaluates the phonetic naturalness of the agent's spoken audio:
+    - Vowel quality (are vowels hitting their phonemic targets?)
+    - Stress contrast (are stressed syllables noticeably longer/louder than unstressed?)
+    - Consonant articulation (stops, fricatives clearly produced?)
+    - Connected speech (natural coarticulation vs clipped, isolated phonemes)
+    - Overall delivery (fluid human-like speech vs flat/robotic TTS)
+
+    This is a diagnostic metric — it measures HOW words are spoken, not whether
+    the correct words were spoken (that is agent_speech_fidelity's job).
+
+    Rating scale per turn:
+        3 — Natural, fluent pronunciation throughout
+        2 — Mostly natural with noticeable but minor issues
+        1 — Clear pronunciation problems that impair naturalness
+    Normalized: (rating - 1) / 2  →  0.0–1.0
+    """
+
+    name = "pronunciation"
+    description = "Diagnostic metric: audio judge evaluation of agent pronunciation quality per turn"
+    category = "diagnostic"
+    role = "assistant"
+    rating_scale = (1, 3)
+    exclude_from_pass_at_k = True


### PR DESCRIPTION
## Summary

- Adds a new **diagnostic** audio judge metric `pronunciation` that evaluates agent speech for phonetic quality (lexical stress, phoneme production) — scoped narrowly so it does not overlap with `agent_speech_fidelity` (entity/content accuracy).
- Uses Gemini as the audio judge, reusing the existing `SpeechFidelityBaseMetric` infrastructure (file upload fallback, retries, per-turn response parsing).
- Binary 0/1 rating per turn with structured per-dimension evidence (`bad_stress`, `bad_sound`)
- The judge receives audio + turn IDs only — no intended text is passed, so the judge must transcribe from audio alone.