### PR TITLE
Stop double sending audio to assistant during perturbations

### DIFF
--- a/src/eva/user_simulator/audio_interface.py
+++ b/src/eva/user_simulator/audio_interface.py
@@ -462,7 +462,7 @@ class BotToBotAudioInterface(AudioInterface):
             self.event_logger.log_audio_end("framework_agent")
         logger.info("🔊 Assistant audio END (silence detected)")
         # Send catch-up silence to cover the detection delay for ElevenLabs
-        if ASSISTANT_CATCHUP_SILENCE_CHUNKS > 0:
+        if ASSISTANT_CATCHUP_SILENCE_CHUNKS > 0 and not self._should_send_ambient_noise():
             await self._send_catchup_silence("user", ASSISTANT_CATCHUP_SILENCE_CHUNKS)
 
     async def _continuous_input_stream(self) -> None:
@@ -529,7 +529,7 @@ class BotToBotAudioInterface(AudioInterface):
 
             # Send assistant silence while waiting for assistant to respond
             # Send in 20ms chunks (same as user silence) for smoother timing
-            if assistant_silence and self._should_send_assistant_silence():
+            if assistant_silence and self._should_send_assistant_silence() and not self._should_send_ambient_noise():
                 # Calculate how many 20ms chunks fit in 250ms (round up to ensure we send enough)
                 # 250ms / 20ms = 12.5, round up to 18 to avoid falling behind real-time
                 chunks_to_send = 18


### PR DESCRIPTION
Audio for perturbations was a lot longer than it should be since we were sending extra perturbed audio when we shouldn't have been.

 1. Fix double-sending during ambient noise (audio_interface.py:532)                                                              


_continuous_input_stream and _send_to_assistant were both sending audio to the pipecat websocket during the "waiting for bot to  
  respond" window when ambient noise was active. Without noise these windows are mutually exclusive (one handles "waiting for bot",
   the other "waiting for user"), but _should_send_ambient_noise() was broad enough to cause both to fire simultaneously —         
  resulting in ~2.44× real-time audio accumulation during every latency window. This was the primary cause of the ~2× audio_mixed
  inflation.

  Fix: Added and not self._should_send_ambient_noise() to the _continuous_input_stream condition so it defers to _send_to_assistant
   when ambient noise is already handling the gap.
   
     2. Fix catch-up silence overlap (audio_interface.py:465)
                                                                                                                                   
  When the assistant finishes speaking, _on_assistant_audio_end() calls _send_catchup_silence (200ms of audio) while
  _send_to_assistant simultaneously starts sending ambient noise — both targeting the same pipecat websocket. This doubled audio   
  for 200ms at every assistant turn-end.                
                                                                                                                                   
  Fix: Added and not self._should_send_ambient_noise() to skip _send_catchup_silence when ambient noise is active, since           
  _send_to_assistant already covers the VAD gap.