### PR TITLE
Save more information on judge failures and rename final failed folder

### DIFF
--- a/src/eva/metrics/base.py
+++ b/src/eva/metrics/base.py
@@ -194,7 +194,13 @@ class BaseMetric(ABC):
         pass
 
     def _log_token_usage(
-        self, context: MetricContext, model_name: str, model_params: dict, prompt: str, usage: dict | None
+        self,
+        context: MetricContext,
+        model_name: str,
+        model_params: dict,
+        prompt: str,
+        usage: dict | None,
+        response_text: str | None = None,
     ) -> None:
         """Append one row of LLM judge token usage to a per-metric CSV and update the run-level JSON summary."""
         if not context.output_dir:
@@ -222,22 +228,36 @@ class BaseMetric(ABC):
         model_id = usage.get("model_name") if usage else None
 
         csv_path = csv_dir / f"{self.name}.csv"
+        header = [
+            "record_id",
+            "model_name",
+            "model_id",
+            "input_tokens",
+            "output_tokens",
+            "timestamp",
+            "model_params",
+            "input_prompt",
+            "output_response",
+        ]
+
+        # If a CSV from a previous version is present, rotate it out so the new
+        # rows don't get mixed with rows missing the output_response column.
+        if csv_path.exists():
+            with open(csv_path, newline="") as f:
+                existing_header = next(csv.reader(f), None)
+            if existing_header != header:
+                legacy_path = csv_dir / f"{self.name}.legacy.csv"
+                i = 1
+                while legacy_path.exists():
+                    legacy_path = csv_dir / f"{self.name}.legacy.{i}.csv"
+                    i += 1
+                csv_path.rename(legacy_path)
+
         write_header = not csv_path.exists()
         with open(csv_path, "a", newline="") as f:
             writer = csv.writer(f)
             if write_header:
-                writer.writerow(
-                    [
-                        "record_id",
-                        "model_name",
-                        "model_id",
-                        "input_tokens",
-                        "output_tokens",
-                        "timestamp",
-                        "model_params",
-                        "input_prompt",
-                    ]
-                )
+                writer.writerow(header)
             writer.writerow(
                 [
                     record_id,
@@ -248,6 +268,7 @@ class BaseMetric(ABC):
                     datetime.now(UTC).isoformat(),
                     json.dumps(model_params) if model_params else None,
                     prompt,
+                    response_text,
                 ]
             )
 
@@ -313,7 +334,7 @@ class TextJudgeMetric(BaseMetric):
         """Call LLM judge and parse response. Returns (parsed_dict, raw_response_text)."""
         messages = [{"role": "user", "content": prompt}]
         response_text, usage = await self.llm_client.generate_text(messages)
-        self._log_token_usage(context, self.llm_client.model, self.llm_client.params, prompt, usage)
+        self._log_token_usage(context, self.llm_client.model, self.llm_client.params, prompt, usage, response_text)
         return parse_judge_response(response_text, context.record_id, self.logger), response_text
 
     def validate_and_normalize_rating(self, response: dict, context: MetricContext) -> tuple[int, float]:
@@ -362,6 +383,7 @@ class ConversationTextJudgeMetric(TextJudgeMetric):
                     score=0.0,
                     normalized_score=0.0,
                     error="Failed to parse judge response",
+                    details={"judge_prompt": prompt, "judge_raw_response": raw_response},
                 )
 
             # Validate and normalize
@@ -479,12 +501,16 @@ class PerTurnConversationJudgeMetric(TextJudgeMetric):
 
             prompt = self.get_judge_prompt(**self.get_prompt_variables(context, transcript_text))
             response_text, usage = await self.llm_client.generate_text([{"role": "user", "content": prompt}])
-            self._log_token_usage(context, self.llm_client.model, self.llm_client.params, prompt, usage)
+            self._log_token_usage(context, self.llm_client.model, self.llm_client.params, prompt, usage, response_text)
             parsed = parse_judge_response_list(response_text)
 
             if parsed is None:
                 return MetricScore(
-                    name=self.name, score=0.0, normalized_score=0.0, error="Failed to parse judge response"
+                    name=self.name,
+                    score=0.0,
+                    normalized_score=0.0,
+                    error="Failed to parse judge response",
+                    details={"judge_prompt": prompt, "judge_raw_response": response_text},
                 )
 
             turn_ids = self.get_expected_turn_ids(context)

--- a/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
+++ b/src/eva/metrics/diagnostic/transcription_accuracy_key_entities.py
@@ -233,7 +233,7 @@ class TranscriptionAccuracyKeyEntitiesMetric(TextJudgeMetric):
         try:
             messages = [{"role": "user", "content": prompt}]
             response_text, usage = await self.llm_client.generate_text(messages)
-            self._log_token_usage(context, self.llm_client.model, self.llm_client.params, prompt, usage)
+            self._log_token_usage(context, self.llm_client.model, self.llm_client.params, prompt, usage, response_text)
             return response_text
         except Exception as e:
             self.logger.error(f"Judge call failed for {context.record_id}: {e}")

--- a/src/eva/metrics/speech_fidelity_base.py
+++ b/src/eva/metrics/speech_fidelity_base.py
@@ -171,7 +171,9 @@ class SpeechFidelityBaseMetric(AudioJudgeMetric):
                     response_text = await self._generate_with_file(uploaded_file, prompt, context)
                 else:
                     response_text, usage = await self.llm_client.generate_text(messages)
-                    self._log_token_usage(context, self.llm_client.model, self.llm_client.params, prompt, usage)
+                    self._log_token_usage(
+                        context, self.llm_client.model, self.llm_client.params, prompt, usage, response_text
+                    )
                 if response_text is None:
                     return None, []
 

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -331,6 +331,11 @@ class BenchmarkRunner:
             else:
                 validation_failed_count += 1
 
+        # Archive the final failing attempts so the directory layout reflects the
+        # failure (downstream tools key off the `_failed_attempt_` suffix).
+        for oid in final_failed_ids:
+            self._archive_failed_attempt(oid, attempt_number)
+
         # STEP 7: Await background metrics, then run final aggregation pass.
         # Background tasks already wrote metrics.json for records validated during the loop.
         # IMPORTANT: Must await all background tasks BEFORE mutating metrics_runner.record_ids
@@ -768,6 +773,11 @@ class BenchmarkRunner:
                         if failure_details:
                             entry["failure_details"] = failure_details
                     final_failures[oid] = entry
+
+        # Archive the final failing attempts so the directory layout reflects the
+        # failure (downstream tools key off the `_failed_attempt_` suffix).
+        for oid in final_failed_ids:
+            self._archive_failed_attempt(oid, max_attempts)
 
         # Build evaluation summary with separate simulation and metrics sections
         llm_generic_error_record_ids = find_records_with_llm_generic_error(self.output_dir, successful_ids)

--- a/tests/integration/test_evaluation_mode.py
+++ b/tests/integration/test_evaluation_mode.py
@@ -309,16 +309,15 @@ async def test_evaluation_mode_max_reruns_reached(eval_config, mock_dataset):
                     assert "attempt" in entry
                     assert "reason" in entry
 
-            # Archiving happens for attempts 1 and 2, not 3 (final stays)
-            for attempt in [1, 2]:
+            # All attempts are archived, including the final one — the original
+            # record dir is moved into _failed_attempt_3 so downstream tools see
+            # the failure via the directory suffix.
+            for attempt in [1, 2, 3]:
                 archive_dir = runner.output_dir / "records" / f"fail_record_1_failed_attempt_{attempt}"
                 assert archive_dir.exists()
 
-            final_failed_attempt_archive = runner.output_dir / "records" / "fail_record_1_failed_attempt_3"
-            assert not final_failed_attempt_archive.exists()
-
             final_record_dir = runner.output_dir / "records" / "fail_record_1"
-            assert final_record_dir.exists()
+            assert not final_record_dir.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Save output for judge failures**: Persist `judge_prompt` and `judge_raw_response` in `MetricScore.details` when judge response parsing fails, and add an `output_response` column to `judge_token_usage/<metric>.csv` so failures (e.g. truncation, refusals, empty content) are diagnosable after the fact. Old-format CSVs are auto-rotated to `<metric>.legacy.csv` on first append.
- **Rename last failed folder with `_failed_attempt`**: Records that exhaust all retry attempts now get their directory archived with the `_failed_attempt_<n>` suffix (consistent with the per-attempt archival pattern), so downstream tools can filter on the suffix to identify final failures.

## Test plan

- [x] `pytest tests/unit/metrics/` (381 passed)
- [ ] Re-run a benchmark and verify `judge_token_usage/<metric>.csv` contains `output_response` and that any parse failure surfaces the raw response in `metrics.json`
- [ ] Verify a final-failed record is renamed to `<id>_failed_attempt_<n>/`