### PR TITLE
Fix metric bugs

### DIFF
--- a/src/eva/metrics/diagnostic/response_speed.py
+++ b/src/eva/metrics/diagnostic/response_speed.py
@@ -66,9 +66,9 @@ class ResponseSpeedMetric(CodeMetric):
             if not context.latency_assistant_turns:
                 return MetricScore(
                     name=self.name,
-                    score=0.0,
+                    score=None,
                     normalized_score=None,
-                    error="No response latencies available (missing audio timestamps)",
+                    skipped=True,
                 )
 
             all_latencies = list(context.latency_assistant_turns.values())

--- a/src/eva/metrics/diagnostic/response_speed.py
+++ b/src/eva/metrics/diagnostic/response_speed.py
@@ -77,9 +77,9 @@ class ResponseSpeedMetric(CodeMetric):
             if not overall_stats:
                 return MetricScore(
                     name=self.name,
-                    score=0.0,
+                    score=None,
                     normalized_score=None,
-                    error="No valid response speeds computed",
+                    skipped=True,
                 )
 
             dropped = [v for v in all_latencies if not (0 < v < 1000)]

--- a/src/eva/metrics/experience/turn_taking.py
+++ b/src/eva/metrics/experience/turn_taking.py
@@ -462,14 +462,14 @@ class TurnTakingMetric(CodeMetric):
 
             if not per_turn_score:
                 self.logger.info(
-                    f"[{context.record_id}] No turns with both user and assistant audio timestamps; skipping metric."
+                    f"[{context.record_id}] No turns with both user and assistant audio timestamps; "
+                    "scoring 0 (turn-taking failed)."
                 )
                 return MetricScore(
                     name=self.name,
                     score=0.0,
-                    normalized_score=None,
+                    normalized_score=0.0,
                     details=details,
-                    error="No turns with both user and assistant audio timestamps",
                 )
 
             mean_score = statistics.mean(per_turn_score.values())

--- a/src/eva/metrics/runner.py
+++ b/src/eva/metrics/runner.py
@@ -498,6 +498,12 @@ class MetricsRunner:
         initial_db_path = record_dir / "initial_scenario_db.json"
         final_db_path = record_dir / "final_scenario_db.json"
 
+        if not result_path.exists():
+            raise FileNotFoundError(
+                f"Conversation result not found at {result_path}. "
+                "The conversation worker did not produce a result.json — the run likely "
+                "failed before completion."
+            )
         if not initial_db_path.exists():
             raise FileNotFoundError(
                 f"Initial scenario database not found at {initial_db_path}. "
@@ -509,11 +515,8 @@ class MetricsRunner:
                 "This is required for deterministic task completion metrics."
             )
 
-        async def _read_optional(path: Path) -> str:
-            return await asyncio.to_thread(path.read_text) if path.exists() else "{}"
-
         result_text, initial_db_text, final_db_text = await asyncio.gather(
-            _read_optional(result_path),
+            asyncio.to_thread(result_path.read_text),
             asyncio.to_thread(initial_db_path.read_text),
             asyncio.to_thread(final_db_path.read_text),
         )

--- a/src/eva/metrics/utils.py
+++ b/src/eva/metrics/utils.py
@@ -10,7 +10,7 @@ from typing import Any
 from pydub import AudioSegment
 
 from eva.models.results import MetricScore
-from eva.utils.json_utils import extract_and_load_json
+from eva.utils.json_utils import extract_and_load_json, extract_and_load_json_iter
 from eva.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -18,6 +18,11 @@ logger = get_logger(__name__)
 
 def parse_judge_response(response_text: str, record_id: str, metric_logger) -> dict | None:
     """Parse LLM judge response using robust JSON extraction.
+
+    Iterates over every JSON value found in the response (prose can contain
+    incidental JSON-like fragments such as `[]` from inline tool-arg references)
+    and returns the largest dict, preferring ones that carry a top-level
+    ``rating`` field — the structured judge answer is by far the biggest object.
 
     Args:
         response_text: Raw response from LLM
@@ -27,26 +32,27 @@ def parse_judge_response(response_text: str, record_id: str, metric_logger) -> d
     Returns:
         Parsed response dict or None if parsing fails
     """
-    response = extract_and_load_json(response_text)
+    candidates: list[dict] = []
+    for obj, _ in extract_and_load_json_iter(response_text):
+        if isinstance(obj, dict):
+            candidates.append(obj)
+        elif isinstance(obj, list):
+            candidates.extend(item for item in obj if isinstance(item, dict))
 
-    if response is None:
-        metric_logger.error(f"Failed to extract JSON from judge response for {record_id}")
+    if not candidates:
+        metric_logger.error(f"Failed to extract JSON dict from judge response for {record_id}")
         metric_logger.error(f"Response text: {response_text}")
         return None
 
-    if isinstance(response, list):
-        dicts = [item for item in response if isinstance(item, dict)]
-        if not dicts:
-            metric_logger.error(f"Judge response is a list with no dict elements for {record_id}")
-            metric_logger.error(f"Response text: {response_text}")
-            return None
-        if len(dicts) > 1:
-            metric_logger.warning(
-                f"Judge response is a list with {len(dicts)} dict elements for {record_id}; using the first."
-            )
-        response = dicts[0]
+    if len(candidates) == 1:
+        return candidates[0]
 
-    return response
+    rated = [d for d in candidates if "rating" in d]
+    if len(rated) == 1:
+        return rated[0]
+    pool = rated or candidates
+    metric_logger.warning(f"Judge response contained {len(pool)} candidate dicts for {record_id}; using the largest.")
+    return max(pool, key=lambda d: len(str(d)))
 
 
 def parse_judge_response_list(response_text: str | None) -> list[dict] | None:

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -251,7 +251,14 @@ class BenchmarkRunner:
 
                     return output_id, result, vr.passed, vr
 
+                except (FileNotFoundError, json.JSONDecodeError) as exc:
+                    # Sample-data problems (missing/corrupt artifacts) — mark as invalid
+                    # and move on. The orchestrator treats vr=None as "not_finished".
+                    logger.warning(f"Skipping {output_id} as invalid: {exc}")
+                    return output_id, exc, False, None
                 except Exception as exc:
+                    # Anything else (KeyError, TypeError, programming bugs, etc.) is
+                    # surfaced loudly so it doesn't get silently swallowed.
                     logger.error(f"Pipeline error for {output_id}: {exc}", exc_info=True)
                     raise
 

--- a/tests/unit/metrics/test_metrics_utils.py
+++ b/tests/unit/metrics/test_metrics_utils.py
@@ -36,6 +36,24 @@ class TestParseJudgeResponse:
         assert result is None
         mock_logger.error.assert_called()
 
+    def test_skips_inline_empty_array_in_prose(self):
+        text = (
+            "The assistant called check_room_availability with equipment_required: [] and "
+            "floor_code: ''. Final answer:\n"
+            '```json\n{"rating": 1, "dimensions": {"x": 1}}\n```'
+        )
+        result = parse_judge_response(text, "rec-1", MagicMock())
+        assert result == {"rating": 1, "dimensions": {"x": 1}}
+
+    def test_picks_largest_dict_when_multiple(self):
+        text = '{"a": 1} and later the real one: {"rating": 2, "dimensions": {"k": "v"}}'
+        result = parse_judge_response(text, "rec-1", MagicMock())
+        assert result == {"rating": 2, "dimensions": {"k": "v"}}
+
+    def test_single_dict_in_list_still_returned(self):
+        result = parse_judge_response('[{"rating": 3}]', "rec-1", MagicMock())
+        assert result == {"rating": 3}
+
 
 class TestParseJudgeResponseList:
     def test_none_input(self):

--- a/tests/unit/metrics/test_response_speed.py
+++ b/tests/unit/metrics/test_response_speed.py
@@ -30,16 +30,17 @@ def _make_trace(tool_call_turn_ids: set[int], all_turn_ids: set[int]) -> list[di
 class TestResponseSpeedMetric:
     @pytest.mark.asyncio
     async def test_no_latencies(self):
-        """Missing latency data returns error."""
+        """Missing latency data is skipped (no error)."""
         metric = ResponseSpeedMetric()
         ctx = make_metric_context()
 
         result = await metric.compute(ctx)
 
         assert result.name == "response_speed"
-        assert result.score == 0.0
+        assert result.score is None
         assert result.normalized_score is None
-        assert result.error is not None
+        assert result.error is None
+        assert result.skipped is True
 
     @pytest.mark.asyncio
     async def test_valid_latencies(self):

--- a/tests/unit/metrics/test_response_speed.py
+++ b/tests/unit/metrics/test_response_speed.py
@@ -72,16 +72,16 @@ class TestResponseSpeedMetric:
 
     @pytest.mark.asyncio
     async def test_all_latencies_filtered_out(self):
-        """When all values are invalid, returns error."""
+        """When all values are invalid, the metric is skipped (no error)."""
         metric = ResponseSpeedMetric()
         ctx = make_metric_context(latency_assistant_turns={1: -5.0, 2: 2000.0})
 
         result = await metric.compute(ctx)
 
-        assert result.score == 0.0
+        assert result.score is None
         assert result.normalized_score is None
-        assert result.error is not None
-        assert "No valid response speeds" in result.error
+        assert result.error is None
+        assert result.skipped is True
 
     @pytest.mark.asyncio
     async def test_single_latency_value(self):

--- a/tests/unit/metrics/test_turn_taking.py
+++ b/tests/unit/metrics/test_turn_taking.py
@@ -268,14 +268,17 @@ class TestComputeScenarios:
         assert ev["yield_score"] == pytest.approx(0.95, abs=1e-3)
 
     @pytest.mark.asyncio
-    async def test_no_timestamps_returns_skipped(self, metric):
+    async def test_no_timestamps_scores_zero(self, metric):
+        """No usable turns means turn-taking failed → score 0, not skipped."""
         context = make_metric_context(
             audio_timestamps_user_turns={},
             audio_timestamps_assistant_turns={},
         )
         result = await metric.compute(context)
-        assert result.normalized_score is None
-        assert result.error
+        assert result.score == 0.0
+        assert result.normalized_score == 0.0
+        assert result.error is None
+        assert result.skipped is False
 
 
 # ---------- Sub-metric structure ----------


### PR DESCRIPTION
## Summary

Bug fixes hit while debugging a stuck rerun loop on a remote benchmark job.

### 1. Judge response parsing — `8e6342b`
`parse_judge_response` used `extract_and_load_json` (first match wins). For metrics like `faithfulness`, judge responses often contain incidental JSON fragments in prose (e.g. `[]` from tool-call references), so the first object wasn't the real answer.

Now iterates every JSON value, flattens lists, and returns the largest dict — preferring ones with a top-level `rating`. Adds a unit test for the multi-object case.

### 2. Pipeline robustness on incomplete trial dirs — `3aa4073`

- `_load_context` substituted `"{}"` for a missing `result.json`, producing a cryptic Pydantic error. Now raises `FileNotFoundError` like the existing scenario_db checks.
- `_run_and_pipeline`'s outer `except Exception: raise` was both hiding bugs and cancelling the whole iteration on a single corrupt artifact. Now catches `FileNotFoundError` / `json.JSONDecodeError` narrowly (record marked invalid, iteration continues); other exceptions still propagate.

### 3. `response_speed` skips on degenerate input — `d3dc008`, `9bb88e5`

Both error branches (all latencies filtered out by the `0 < v < 1000s` sanity range, or `latency_assistant_turns` empty because the agent never produced an overlapping turn) now return `score=None, skipped=True`. `response_speed` is diagnostic — these cases are already flagged by `task_completion`, `conversation_progression`, `turn_taking`.

### 4. `turn_taking` scores 0 on no-overlap — `9bb88e5`

When no turn has both user and assistant audio (agent didn't participate), this is a turn-taking failure, not missing data. Now scores `0.0` instead of erroring.

## Test plan
- [x] `pytest tests/unit/metrics/{test_metrics_utils,test_response_speed,test_turn_taking}.py`
- [x] `pytest tests/unit/orchestrator tests/unit/metrics/test_runner.py tests/integration/test_evaluation_mode.py` — 94 tests green