### PR TITLE
Improve faithfulness and conversation progression for S2S

### DIFF
--- a/configs/prompts/judge.yaml
+++ b/configs/prompts/judge.yaml
@@ -296,8 +296,10 @@ judge:
       ## Current Date/Time
       {current_date_time}
 
-      ## Understanding User Turns
+      ## Understanding User and Assistant Turns
       {user_turns_disclaimer}
+
+      {assistant_turns_disclaimer}
 
       ## Full Conversation with Tools
       {conversation_trace}
@@ -358,6 +360,8 @@ judge:
       - Filtering tool results based on user-stated constraints (e.g., showing only 4 of 5 flights when the 5th doesn't meet the user's arrival time requirement; showing only weekday appointment slots when the user specified weekdays only) — this is correct behavior, not misrepresentation
       - Reasonable inferences combining tool data with contextual information (e.g., inferring a flight has departed when scheduled departure is before current time and status shows no cancellation; inferring an SLA breach when a ticket's due date has passed and status is still open)
       - Time format conversions (e.g., 16:40 = 4:40 PM, 17:00 = 5:00 PM)
+
+      {misrepresentation_pipeline_note}
 
       **Verification requirements:** When checking the assistant's statements against tool results: (1) carefully compute differences/totals (e.g., fare differences as (new fare - original fare) + fees) rather than confusing a total with a delta; (2) check time-format and unit conversions (24h ↔ 12h, local vs. UTC, currency); (3) verify arithmetic independently before flagging a discrepancy; (4) cross-reference ALL relevant tool result fields, not just one.
 

--- a/configs/prompts/judge.yaml
+++ b/configs/prompts/judge.yaml
@@ -171,6 +171,8 @@ judge:
 
       This dimension is about the assistant **forgetting or ignoring known facts**, regardless of how that failure manifests (re-asking, wrong assumptions, ignoring constraints).
 
+      {information_loss_pipeline_note}
+
       **IS a flag:**
       - Re-asking the user for information they already provided (e.g., asking for the confirmation number or reference ID after the user stated it and it was used successfully).
       - Ignoring a constraint the user explicitly stated (e.g., the user ruled out a particular action but the assistant still asks about it or asks for the details that would only be needed to take that action)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "eva"
-version = "0.1.3"
+version = "0.1.4"
 description = "A New End-to-end Framework for Evaluating Voice Agents (EVA)"
 authors = [
     { name = "Tara Bogavelli" },

--- a/src/eva/__init__.py
+++ b/src/eva/__init__.py
@@ -3,7 +3,7 @@
 End-to-end evaluation framework for voice assistants using Pipecat and ElevenLabs.
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # Bump simulation_version when changes affect benchmark outputs (agent code,
 # user simulator, orchestrator, simulation prompts, agent configs, tool mocks).
@@ -11,4 +11,4 @@ simulation_version = "0.1.5"
 
 # Bump metrics_version when changes affect metric computation (metrics code,
 # judge prompts, pricing tables, postprocessor).
-metrics_version = "0.1.5"
+metrics_version = "0.1.6"

--- a/src/eva/metrics/accuracy/faithfulness.py
+++ b/src/eva/metrics/accuracy/faithfulness.py
@@ -4,7 +4,11 @@ import json
 from typing import Any
 
 from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
-from eva.metrics.pipeline_prompts import get_user_turns_disclaimer
+from eva.metrics.pipeline_prompts import (
+    get_assistant_turns_disclaimer,
+    get_misrepresentation_pipeline_note,
+    get_user_turns_disclaimer,
+)
 from eva.metrics.registry import register_metric
 from eva.metrics.utils import build_binary_flag_sub_metrics
 from eva.models.results import MetricScore
@@ -59,7 +63,6 @@ class FaithfulnessJudgeMetric(ConversationTextJudgeMetric):
 
     def get_prompt_variables(self, context: MetricContext, transcript_text: str) -> dict[str, Any]:
         """Return variables for prompt formatting."""
-        user_turns_disclaimer = get_user_turns_disclaimer(context.is_audio_native)
         if context.is_audio_native:
             disambiguation_context = _S2S_DISAMBIGUATION_CONTEXT
         else:
@@ -71,7 +74,9 @@ class FaithfulnessJudgeMetric(ConversationTextJudgeMetric):
             "available_tools": json.dumps(context.agent_tools, indent=4),
             "conversation_trace": transcript_text,
             "current_date_time": context.current_date_time,
-            "user_turns_disclaimer": user_turns_disclaimer,
+            "user_turns_disclaimer": get_user_turns_disclaimer(context.is_audio_native),
+            "assistant_turns_disclaimer": get_assistant_turns_disclaimer(context.is_audio_native),
+            "misrepresentation_pipeline_note": get_misrepresentation_pipeline_note(context.is_audio_native),
             "disambiguation_context": disambiguation_context,
         }
 

--- a/src/eva/metrics/experience/conversation_progression.py
+++ b/src/eva/metrics/experience/conversation_progression.py
@@ -3,7 +3,11 @@
 from typing import Any
 
 from eva.metrics.base import ConversationTextJudgeMetric, MetricContext
-from eva.metrics.pipeline_prompts import get_assistant_turns_disclaimer, get_user_turns_disclaimer
+from eva.metrics.pipeline_prompts import (
+    get_assistant_turns_disclaimer,
+    get_information_loss_pipeline_note,
+    get_user_turns_disclaimer,
+)
 from eva.metrics.registry import register_metric
 from eva.metrics.utils import build_binary_flag_sub_metrics
 from eva.models.results import MetricScore
@@ -38,6 +42,7 @@ class ConversationProgressionJudgeMetric(ConversationTextJudgeMetric):
             "conversation_trace": transcript_text,
             "user_turns_disclaimer": get_user_turns_disclaimer(context.is_audio_native),
             "assistant_turns_disclaimer": get_assistant_turns_disclaimer(context.is_audio_native),
+            "information_loss_pipeline_note": get_information_loss_pipeline_note(context.is_audio_native),
         }
 
     def build_metric_score(

--- a/src/eva/metrics/pipeline_prompts.py
+++ b/src/eva/metrics/pipeline_prompts.py
@@ -38,7 +38,32 @@ CASCADE_ASSISTANT_TURNS_DISCLAIMER = (
     "know what the user actually said or heard beyond the transcript."
 )
 
-S2S_ASSISTANT_TURNS_DISCLAIMER = ""
+S2S_ASSISTANT_TURNS_DISCLAIMER = (
+    "**About assistant turns:** This is a **speech-to-speech** system — the agent produces audio directly, "
+    "with no separate intended-text step. The assistant turns shown here are **STT transcriptions of the "
+    "agent's audio**, not text the LLM wrote. Audio articulation fidelity (whether the agent *spoke* an "
+    "entity clearly and correctly) is scored separately by the `agent_speech_fidelity` metric on the "
+    "actual audio — do not penalize the agent here for what may be TTS-rendering or STT-transcription "
+    "artifacts in its turns. Tool call parameters and tool responses shown in the trace are the literal "
+    "values the agent sent and received via the API, not audio — if a tool parameter looks wrong, the "
+    "agent really sent it that way; if the agent's claim contradicts a tool response, the tool truly "
+    "returned the value shown."
+)
+
+
+# Per-dimension, pipeline-specific scoping notes. Empty string for pipelines where
+# no carve-out is needed; injected via dedicated placeholders in the judge prompt.
+
+S2S_MISREPRESENTATION_NOTE = (
+    "**Speech-to-speech scoping for this dimension.** Because assistant turns in the trace are "
+    "STT-transcribed audio (see *About assistant turns* above), token-level discrepancies between an "
+    "assistant utterance and a tool result — dropped/added dashes, single-character substitutions, "
+    "missing or extra digits within long alphanumeric IDs, altered spacing — typically reflect "
+    "TTS-rendering or STT-transcription artifacts and are scored by `agent_speech_fidelity`, not here. "
+    "Only flag `misrepresenting_tool_result` when the discrepancy is structural/semantic (wrong field, "
+    "wrong order of magnitude, wrong category) or when downstream signals — subsequent tool calls, "
+    "follow-up actions, user objections — show the agent was internally operating on a wrong value."
+)
 
 
 def get_user_turns_disclaimer(is_audio_native: bool) -> str:
@@ -47,9 +72,10 @@ def get_user_turns_disclaimer(is_audio_native: bool) -> str:
 
 
 def get_assistant_turns_disclaimer(is_audio_native: bool) -> str:
-    """Return the assistant-turns disclaimer matching the pipeline type.
-
-    Empty string for speech-to-speech, since assistant turns there are not the
-    intended-text/TTS-source distinction that cascade has.
-    """
+    """Return the assistant-turns disclaimer matching the pipeline type."""
     return S2S_ASSISTANT_TURNS_DISCLAIMER if is_audio_native else CASCADE_ASSISTANT_TURNS_DISCLAIMER
+
+
+def get_misrepresentation_pipeline_note(is_audio_native: bool) -> str:
+    """Return the pipeline-specific scoping note for the misrepresenting_tool_result dimension."""
+    return S2S_MISREPRESENTATION_NOTE if is_audio_native else ""

--- a/src/eva/metrics/pipeline_prompts.py
+++ b/src/eva/metrics/pipeline_prompts.py
@@ -65,6 +65,21 @@ S2S_MISREPRESENTATION_NOTE = (
     "follow-up actions, user objections — show the agent was internally operating on a wrong value."
 )
 
+S2S_INFORMATION_LOSS_NOTE = (
+    "**Speech-to-speech scoping for this dimension.** Because assistant turns in the trace are "
+    "STT-transcribed audio (see *About assistant turns* above), variant token-level readings of the "
+    "same alphanumeric identifier across nearby assistant turns — dropped/added dashes, single-character "
+    "substitutions, missing or extra digits within long IDs, altered spacing or capitalization — typically "
+    "reflect TTS-rendering or STT-transcription artifacts on a value the agent is reading consistently in "
+    "audio. These are scored by `agent_speech_fidelity`, not here. "
+    "Only flag `information_loss` when the discrepancy is structural/semantic (different entity, wrong "
+    "field, wrong category — e.g., addressing the user by an entirely different first name, or referencing "
+    "a different person/record than the tool returned), or when downstream signals — subsequent tool calls "
+    "made with a wrong value, follow-up actions taken on stale data, user objections that the agent then "
+    "fails to incorporate — show the agent was internally operating on a wrong value or had genuinely lost "
+    "track of the established fact."
+)
+
 
 def get_user_turns_disclaimer(is_audio_native: bool) -> str:
     """Return the user-turns disclaimer matching the pipeline type."""
@@ -79,3 +94,8 @@ def get_assistant_turns_disclaimer(is_audio_native: bool) -> str:
 def get_misrepresentation_pipeline_note(is_audio_native: bool) -> str:
     """Return the pipeline-specific scoping note for the misrepresenting_tool_result dimension."""
     return S2S_MISREPRESENTATION_NOTE if is_audio_native else ""
+
+
+def get_information_loss_pipeline_note(is_audio_native: bool) -> str:
+    """Return the pipeline-specific scoping note for the information_loss dimension."""
+    return S2S_INFORMATION_LOSS_NOTE if is_audio_native else ""


### PR DESCRIPTION
## Summary

**Faithfulness — S2S carve-out for `misrepresenting_tool_result`.** S2S pipelines were getting r=1 on token-level TTS/STT artifacts on tool IDs (e.g., `REQ-FAC-0ddb46f41d67` → `REQFAC0DDB46F1D67`). Articulation fidelity is `agent_speech_fidelity`'s scope, not faithfulness's. Populated the empty `S2S_ASSISTANT_TURNS_DISCLAIMER` (orientation: assistant turns are STT'd audio, articulation goes through `agent_speech_fidelity`) and added a dimension-specific `S2S_MISREPRESENTATION_NOTE` injected only into `misrepresenting_tool_result` for S2S. Cascade pipelines unchanged.

**Conversation progression — same approach for `information_loss` and `redundant_statements`.** Same pattern applied: pipeline-specific scoping notes carve out token-level transcription artifacts that should be evaluated by `agent_speech_fidelity` instead of being double-counted.

**Validation.** Re-judged 15 hand-picked cases through `local/rerun_faithfulness.py` (9 TTS-mangling drops + 4 S2S semantic stays + 2 cascade controls):
- 9/9 drops: MTR moved from 1 → 2/3.
- 6/6 stays: overall=1 preserved; semantic violations still flagged in MTR or hallucination per scope.
- 0 cases lost the underlying signal.