### PR TITLE
Change how to run multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ pip install -e ".[dev]"
 **Key Environment Variables:**
 ```bash
 # Framework Configuration
-EVA_DOMAIN=airline           # Domain-based path conventions
-EVA_MAX_CONCURRENT_CONVERSATIONS=5   # Max parallel conversations
+EVA_DOMAIN=airline
+EVA_MAX_CONCURRENT_CONVERSATIONS=5
 EVA_DEBUG=false                       # Run only 1 record for testing when enabled
 EVA_RECORD_IDS=1.2.1,1.2.2            # Run specific records only (remove to run all records)
 
 # Pipeline Model Configuration (nested under EVA_MODEL__)
-EVA_MODEL__LLM=gpt-5-mini                # LLM model name (must match EVA_MODEL_LIST)
+EVA_MODEL__LLM=gpt-5-mini             # LLM model name (must match EVA_MODEL_LIST)
 EVA_MODEL__STT=deepgram               # deepgram | openai_whisper
 EVA_MODEL__TTS=cartesia               # cartesia | elevenlabs
 
@@ -116,25 +116,40 @@ EVA_LOG_LEVEL=INFO                    # DEBUG | INFO | WARNING | ERROR
 
 See `.env.example` for the complete list of configuration options.
 
-### Running the framework
+### Running EVA
+
+#### Running with CLI Arguments
+
+The CLI arguments take precedence over environment variables, which in turn take precedence over the `.env` file.
 
 ```bash
-# Run with domain-based conventions (easiest):
-EVA_DOMAIN=airline python main.py
-# Automatically uses:
-#   data/airline_dataset.jsonl
-#   configs/agents/airline_agent.yaml
-#   data/airline_scenarios/
-
-# Run with CLI overrides
-python main.py --model.llm gpt-5-mini --max-concurrent-conversations 10
+eva --domain airline --model.llm gpt-5-mini --max-concurrent-conversations 10
 ```
 
-### Running Metrics
+#### Running Multiple Configurations
+
+Here is an example of shell loop to sweep over domains, models, or any combination of parameters.
+Each iteration is an independent `eva` run. The loop continues on failure and exits with the last non-zero exit code.
 
 ```bash
-# Re-run specific metrics on an existing run
-python main.py \
+exit_code=0;
+for domain in airline itsm medical_hr; do
+    for llm in gpt-5-mini gpt-5; do
+        eva --domain "$domain" --model.llm "$llm" || exit_code=$?;
+    done;
+done;
+exit $exit_code
+```
+
+> [!TIP]
+> If you need a single command, like in Docker, you can wrap the above script with `sh -c '...'`.
+
+#### Running Specific Metrics
+
+Re-run specific metrics on an existing run.
+
+```bash
+eva \
     --run-id <existing_run_id> \
     --metrics task_completion,faithfulness,conciseness
 ```

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ done;
 exit $exit_code
 ```
 
-> [!TIP]
-> If you need a single command, like in Docker, you can wrap the above script with `sh -c '...'`.
+:bulb: If you need a single command, like in Docker, you can wrap the shell script with `sh -c '...'`.
 
 #### Running Specific Metrics
 

--- a/src/eva/cli.py
+++ b/src/eva/cli.py
@@ -5,49 +5,9 @@ Used by both the `eva` console script (installed via pip/uv) and `python main.py
 """
 
 import asyncio
-import os
 import sys
 
 from pydantic import ValidationError
-
-
-def _extract_domain_spec() -> tuple[str | None, bool]:
-    """Return (raw_domain_spec, came_from_argv).
-
-    Looks at --domain / --domain=... in sys.argv first, then EVA_DOMAIN env var.
-    """
-    argv = sys.argv
-    for i, arg in enumerate(argv):
-        if arg == "--domain" and i + 1 < len(argv):
-            return argv[i + 1], True
-        if arg.startswith("--domain="):
-            return arg.split("=", 1)[1], True
-    env = os.environ.get("EVA_DOMAIN")
-    if env is not None:
-        return env, False
-    return None, False
-
-
-def _strip_domain_from_argv() -> None:
-    """Remove --domain (and its value) from sys.argv in place."""
-    argv = sys.argv
-    out = [argv[0]]
-    i = 1
-    while i < len(argv):
-        a = argv[i]
-        if a == "--domain":
-            i += 2
-            continue
-        if a.startswith("--domain="):
-            i += 1
-            continue
-        out.append(a)
-        i += 1
-    sys.argv = out
-
-
-def _has_explicit_run_id() -> bool:
-    return any(a == "--run-id" or a.startswith("--run-id=") for a in sys.argv) or "EVA_RUN_ID" in os.environ
 
 
 def main():
@@ -56,60 +16,15 @@ def main():
     # Heavy deps (pipecat, litellm, etc.) are imported only in run_benchmark.
     from eva.models.config import RunConfig
 
-    spec, _ = _extract_domain_spec()
-    domains = [d.strip() for d in spec.split(",")] if spec and "," in spec else None
-
-    if domains is None:
-        # Single-domain path — unchanged behavior.
-        try:
-            config = RunConfig(_cli_parse_args=True, _env_file=".env")
-        except ValidationError as e:
-            print(e, file=sys.stderr)
-            sys.exit(1)
-
-        from eva.run_benchmark import run_benchmark
-
-        sys.exit(asyncio.run(run_benchmark(config)))
-
-    # Multi-domain path: loop, one RunConfig + run_benchmark per domain.
-    # Dedupe preserving order, drop empties.
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for d in domains:
-        if d and d not in seen:
-            seen.add(d)
-            ordered.append(d)
-
-    explicit_run_id = _has_explicit_run_id()
-    original_env = os.environ.get("EVA_DOMAIN")
-    _strip_domain_from_argv()  # prevent pydantic-settings from re-reading the comma list
+    try:
+        config = RunConfig(_cli_parse_args=True, _env_file=".env")
+    except ValidationError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
     from eva.run_benchmark import run_benchmark
 
-    worst_exit = 0
-    try:
-        for domain in ordered:
-            os.environ["EVA_DOMAIN"] = domain
-            try:
-                config = RunConfig(_cli_parse_args=True, _env_file=".env")
-            except ValidationError as e:
-                print(f"[domain={domain}] {e}", file=sys.stderr)
-                worst_exit = max(worst_exit, 1)
-                continue
-
-            if explicit_run_id:
-                config.run_id = f"{config.run_id}_{domain}"
-
-            print(f"\n=== Running domain: {domain} ===\n", file=sys.stderr)
-            exit_code = asyncio.run(run_benchmark(config))
-            worst_exit = max(worst_exit, exit_code)
-    finally:
-        if original_env is None:
-            os.environ.pop("EVA_DOMAIN", None)
-        else:
-            os.environ["EVA_DOMAIN"] = original_env
-
-    sys.exit(worst_exit)
+    sys.exit(asyncio.run(run_benchmark(config)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current implementation for running multiple domains doesn't scale to running multiple perturbations, models, or other configurations. Also, that code felt like fighting against Pydantic. So, I suggest:
1. [Revert "Allow running multiple domains"](https://github.com/ServiceNow/eva/commit/a48f9e5d56cd92adae129d70d7274827ce82bc82) for now, so we can think of a more generalizable and Pydantic-friendly implementation.
2. [Document how to run multiple domains, models, etc.](https://github.com/ServiceNow/eva/commit/fb18522cdfd30bec0e08186b499f01d71dd493f9) using simple shell loops. Although not a first-class EVA feature, this is quite simple and generalizable.

What do you think?

Here is what I added in the REDME:

---

#### Running Multiple Configurations

Here is an example of shell loop to sweep over domains, models, or any combination of parameters.
Each iteration is an independent `eva` run. The loop continues on failure and exits with the last non-zero exit code.

```bash
exit_code=0;
for domain in airline itsm medical_hr; do
    for llm in gpt-5-mini gpt-5; do
        eva --domain "$domain" --model.llm "$llm" || exit_code=$?;
    done;
done;
exit $exit_code
```

:bulb: If you need a single command, like in Docker, you can wrap the shell script with `sh -c '...'`.