### PR TITLE
Classify Ultravox as AUDIO_LLM in get_pipeline_type

### DIFF
--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -349,10 +349,13 @@ def get_pipeline_type(model_data: dict | Any) -> PipelineType:
     """
     mode = _model_config_discriminator(model_data)
     if mode == "s2s":
-        # ElevenLabs uses s2s_params for configuration but is a cascade pipeline internally
         s2s_value = model_data.get("s2s")
+        # ElevenLabs uses s2s_params for configuration but is a cascade pipeline internally
         if s2s_value == "elevenlabs":
             return PipelineType.CASCADE
+        # Ultravox uses s2s_params for plumbing but is an audio-LLM (audio in, text out, separate TTS)
+        if s2s_value == "ultravox":
+            return PipelineType.AUDIO_LLM
         return PipelineType.S2S
     if mode == "audio_llm":
         return PipelineType.AUDIO_LLM


### PR DESCRIPTION
Ultravox is wired through the s2s code path (UltravoxRealtimeLLMService) because that's the right plumbing, but semantically it's an audio-LLM (audio in, text out + bundled audio synthesis), not an end-to-end S2S model. Mirror the existing ElevenLabs special case so metrics route through the AUDIO_LLM postprocessor branch (audit_log assistant trace, pipecat tts_text/llm_response, speakability) instead of the S2S branch.