### PR TITLE
add gemini ALM support

### DIFF
--- a/scripts/run_text_only.py
+++ b/scripts/run_text_only.py
@@ -606,6 +606,7 @@ async def run_record(
         agent_role=raw_agent_config.get("role", ""),
         agent_instructions=agent_instructions,
         agent_tools=raw_agent_config.get("tools", []),
+        agent_id=raw_agent_config.get("id", ""),
         current_date_time=record.current_date_time,
         num_turns=stats["num_turns"],
         num_tool_calls=stats["num_tool_calls"],

--- a/src/eva/assistant/agentic/audio_llm_system.py
+++ b/src/eva/assistant/agentic/audio_llm_system.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from eva.assistant.agentic.audit_log import AuditLog
 from eva.assistant.agentic.system import AgenticSystem
-from eva.assistant.pipeline.alm_vllm import ALMvLLMClient
+from eva.assistant.pipeline.alm_base import BaseALMClient
 from eva.assistant.tools.tool_executor import ToolExecutor
 from eva.models.agents import AgentConfig
 from eva.utils.logging import get_logger
@@ -37,7 +37,7 @@ class AudioLLMAgenticSystem(AgenticSystem):
         agent: AgentConfig,
         tool_handler: ToolExecutor,
         audit_log: AuditLog,
-        alm_client: ALMvLLMClient,
+        alm_client: BaseALMClient,
         output_dir: Path | None = None,
     ):
         super().__init__(
@@ -48,7 +48,7 @@ class AudioLLMAgenticSystem(AgenticSystem):
             llm_client=alm_client,
             output_dir=output_dir,
         )
-        self.alm_client: ALMvLLMClient = alm_client
+        self.alm_client: BaseALMClient = alm_client
 
         # Override system prompt with audio-LLM specific version
         self.system_prompt = self.prompt_manager.get_prompt(

--- a/src/eva/assistant/pipecat_server.py
+++ b/src/eva/assistant/pipecat_server.py
@@ -364,8 +364,7 @@ class PipecatAssistantServer(AbstractAssistantServer):
                 input_transcription_context_filter = InputTranscriptionContextFilter()
                 input_transcription_processor = AudioTranscriptionProcessor(
                     audio_collector=audio_llm_audio_collector,
-                    model=self.pipeline_config.audio_llm_params.get("model"),
-                    params=self.pipeline_config.audio_llm_params,
+                    alm_client=alm_client,
                     sample_rate=SAMPLE_RATE,
                 )
 

--- a/src/eva/assistant/pipeline/alm_base.py
+++ b/src/eva/assistant/pipeline/alm_base.py
@@ -1,0 +1,179 @@
+"""Abstract base class for audio language model clients.
+
+Audio-LLM clients accept audio input + text context and return text output.
+Concrete implementations (vLLM-hosted models, Gemini, etc.) differ in auth,
+endpoint shape, and provider-specific request quirks, but share:
+
+- A common interface (build_audio_user_message, complete, transcribe)
+- Audio utilities (PCM resampling, WAV encoding)
+- Common numeric configuration (sample rate, retry policy, etc.)
+
+The methods used by the audio-LLM pipeline:
+
+- build_audio_user_message: serialize a chunk of PCM audio into a chat message
+- complete: chat completion with audio + text + tool support (used by AudioLLMAgenticSystem)
+- transcribe: transcription-only call (used by AudioTranscriptionProcessor for
+  logging and conversation history, since a regular multimodal LLM does not
+  surface a separate transcription stream)
+"""
+
+import base64
+import io
+import struct
+import wave
+from abc import ABC, abstractmethod
+from typing import Any
+
+# Default audio parameters (Ultravox: 16kHz PCM16 mono)
+DEFAULT_SAMPLE_RATE = 16000
+DEFAULT_NUM_CHANNELS = 1
+DEFAULT_SAMPLE_WIDTH = 2  # 16-bit PCM
+
+VALID_SAMPLE_RATES = {8000, 16000, 24000, 44100, 48000}
+
+# Default system prompt for audio-LLM transcription calls. Used by client
+# transcribe() implementations when no override is supplied, and by
+# AudioTranscriptionProcessor when no system_prompt is configured.
+DEFAULT_TRANSCRIPTION_PROMPT = """You are an audio transcriber. Your job is to transcribe the input audio to text exactly as it was said by the user.
+
+Rules:
+- Respond with an exact transcription of the audio input only.
+- Do not include any text other than the transcription.
+- Do not explain or add to your response.
+- Transcribe the audio input simply and precisely.
+- If the audio is not clear, respond with exactly: UNCLEAR"""
+
+
+def pcm16_to_wav_bytes(
+    pcm_data: bytes,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    num_channels: int = DEFAULT_NUM_CHANNELS,
+    sample_width: int = DEFAULT_SAMPLE_WIDTH,
+) -> bytes:
+    """Wrap raw PCM bytes in a WAV container."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(num_channels)
+        wf.setsampwidth(sample_width)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_data)
+    return buf.getvalue()
+
+
+def resample_pcm16(pcm_data: bytes, from_rate: int, to_rate: int) -> bytes:
+    """Resample PCM16 mono audio via linear interpolation."""
+    if from_rate == to_rate:
+        return pcm_data
+    num_samples = len(pcm_data) // 2
+    if num_samples == 0:
+        return pcm_data
+    samples = struct.unpack(f"<{num_samples}h", pcm_data)
+    ratio = to_rate / from_rate
+    out_count = int(num_samples * ratio)
+    out_samples = []
+    for i in range(out_count):
+        src_idx = i / ratio
+        idx0 = int(src_idx)
+        idx1 = min(idx0 + 1, num_samples - 1)
+        frac = src_idx - idx0
+        val = int(samples[idx0] * (1 - frac) + samples[idx1] * frac)
+        val = max(-32768, min(32767, val))
+        out_samples.append(val)
+    return struct.pack(f"<{len(out_samples)}h", *out_samples)
+
+
+class BaseALMClient(ABC):
+    """Common interface and shared behavior for audio-LLM clients."""
+
+    def __init__(
+        self,
+        model: str,
+        temperature: float = 0.0,
+        max_tokens: int = 512,
+        max_retries: int = 5,
+        initial_delay: float = 1.0,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        num_channels: int = DEFAULT_NUM_CHANNELS,
+        sample_width: int = DEFAULT_SAMPLE_WIDTH,
+    ):
+        if sample_rate not in VALID_SAMPLE_RATES:
+            raise ValueError(f"Invalid sample_rate={sample_rate}. Must be one of {sorted(VALID_SAMPLE_RATES)}")
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.max_retries = max_retries
+        self.initial_delay = initial_delay
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+        self.sample_width = sample_width
+
+    def _audio_to_b64_wav(self, audio_bytes: bytes, source_sample_rate: int) -> str:
+        """Resample, WAV-wrap, and base64-encode raw PCM16 audio."""
+        resampled = resample_pcm16(audio_bytes, source_sample_rate, self.sample_rate)
+        wav_bytes = pcm16_to_wav_bytes(
+            resampled,
+            sample_rate=self.sample_rate,
+            num_channels=self.num_channels,
+            sample_width=self.sample_width,
+        )
+        return base64.b64encode(wav_bytes).decode("utf-8")
+
+    def build_audio_user_message(
+        self,
+        audio_bytes: bytes,
+        source_sample_rate: int,
+        text_hint: str = "",
+    ) -> dict[str, Any]:
+        """Build a user message with audio content. Provider-specific shape comes
+        from the subclass _audio_content_part hook."""
+        audio_b64 = self._audio_to_b64_wav(audio_bytes, source_sample_rate)
+        content: list[dict[str, Any]] = []
+        if text_hint:
+            content.append({"type": "text", "text": text_hint})
+        content.append(self._audio_content_part(audio_b64))
+        return {"role": "user", "content": content}
+
+    @staticmethod
+    def _is_retryable(error: Exception) -> bool:
+        """Check if an error is retryable (connection, timeout, server errors)."""
+        error_str = str(error).lower()
+        retryable_patterns = [
+            "connection",
+            "timeout",
+            "502",
+            "503",
+            "504",
+            "rate limit",
+            "too many requests",
+            "server error",
+        ]
+        return any(pattern in error_str for pattern in retryable_patterns)
+
+    @abstractmethod
+    def _audio_content_part(self, audio_b64: str) -> dict[str, Any]:
+        """Return the provider-specific content dict for a base64-WAV audio blob."""
+
+    @abstractmethod
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        """Chat completion with audio and tool support.
+
+        Returns (message_or_content, stats_dict). When tool_calls are present
+        on the response, returns the full message object; otherwise returns
+        the content string.
+        """
+
+    @abstractmethod
+    async def transcribe(
+        self,
+        audio_bytes: bytes,
+        source_sample_rate: int,
+        system_prompt: str | None = None,
+    ) -> str | None:
+        """Transcribe a chunk of PCM16 audio to text.
+
+        Returns the transcript, or None on error / empty audio.
+        """

--- a/src/eva/assistant/pipeline/alm_base.py
+++ b/src/eva/assistant/pipeline/alm_base.py
@@ -124,8 +124,10 @@ class BaseALMClient(ABC):
         source_sample_rate: int,
         text_hint: str = "",
     ) -> dict[str, Any]:
-        """Build a user message with audio content. Provider-specific shape comes
-        from the subclass _audio_content_part hook."""
+        """Build a user message with audio content.
+
+        Provider-specific shape comes from the subclass _audio_content_part hook.
+        """
         audio_b64 = self._audio_to_b64_wav(audio_bytes, source_sample_rate)
         content: list[dict[str, Any]] = []
         if text_hint:

--- a/src/eva/assistant/pipeline/alm_gemini.py
+++ b/src/eva/assistant/pipeline/alm_gemini.py
@@ -1,0 +1,237 @@
+"""Audio language model client for Gemini via OpenAI-compatible API.
+
+Two auth modes are supported:
+
+1. API key (Gemini Developer API) — uses
+   https://generativelanguage.googleapis.com/v1beta/openai/
+
+2. Vertex AI (service-account / ADC) — uses
+   https://{LOCATION}-aiplatform.googleapis.com/v1beta1/projects/{PROJECT}/
+   locations/{LOCATION}/endpoints/openapi
+   Auth is via an OAuth access token minted from Application Default
+   Credentials (e.g. GOOGLE_APPLICATION_CREDENTIALS=service-account.json).
+
+Both surfaces accept OpenAI-style chat.completions with `input_audio` content,
+so the on-the-wire shape is identical and the client only differs in URL/auth.
+"""
+
+import asyncio
+import datetime
+import time
+from typing import Any
+
+import google.auth
+import google.auth.transport.requests
+from openai import AsyncOpenAI
+
+from eva.assistant.pipeline.alm_base import (
+    DEFAULT_NUM_CHANNELS,
+    DEFAULT_SAMPLE_RATE,
+    DEFAULT_SAMPLE_WIDTH,
+    DEFAULT_TRANSCRIPTION_PROMPT,
+    BaseALMClient,
+)
+from eva.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+VERTEX_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+# Refresh ADC token when fewer than this many seconds remain on it.
+TOKEN_REFRESH_MARGIN_SEC = 300
+
+
+def _vertex_base_url(project: str, location: str) -> str:
+    # The "global" location uses the un-prefixed aiplatform.googleapis.com host;
+    # all regional locations use {location}-aiplatform.googleapis.com.
+    host = "aiplatform.googleapis.com" if location == "global" else f"{location}-aiplatform.googleapis.com"
+    return f"https://{host}/v1beta1/projects/{project}/locations/{location}/endpoints/openapi/"
+
+
+class ALMGeminiClient(BaseALMClient):
+    """Audio-LLM client for Gemini's OpenAI-compatible endpoint."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        model: str = "gemini-3-flash-preview",
+        temperature: float = 0.0,
+        max_tokens: int = 1024,
+        max_retries: int = 5,
+        initial_delay: float = 1.0,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        num_channels: int = DEFAULT_NUM_CHANNELS,
+        sample_width: int = DEFAULT_SAMPLE_WIDTH,
+        project: str | None = None,
+        location: str | None = None,
+    ):
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            max_retries=max_retries,
+            initial_delay=initial_delay,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            sample_width=sample_width,
+        )
+
+        self._adc_credentials = None  # Set in vertex mode for token refresh
+        self._is_vertex = bool(project and location)
+
+        if self._is_vertex:
+            # Vertex OpenAI-compat requires the "google/" or "publishers/google/models/"
+            # prefix on the model id; auto-add the simple form if the caller passed a bare name.
+            if "/" not in self.model:
+                self.model = f"google/{self.model}"
+            self.base_url = (base_url or _vertex_base_url(project, location)).rstrip("/") + "/"
+            self._adc_credentials, detected_project = google.auth.default(scopes=VERTEX_SCOPES)
+            logger.info(
+                f"ALMGeminiClient using Vertex AI: project={project} (ADC project={detected_project}), "
+                f"location={location}"
+            )
+            token = self._refresh_adc_token()
+            self._client = AsyncOpenAI(
+                base_url=self.base_url,
+                api_key=token,
+                timeout=120.0,
+            )
+        else:
+            if not api_key:
+                raise ValueError(
+                    "ALMGeminiClient requires either api_key (Gemini Developer API) "
+                    "or project+location (Vertex AI via ADC)."
+                )
+            self.base_url = (base_url or DEFAULT_GEMINI_BASE_URL).rstrip("/") + "/"
+            self._client = AsyncOpenAI(
+                base_url=self.base_url,
+                api_key=api_key,
+                timeout=120.0,
+            )
+
+        logger.info(
+            f"Initialized ALMGeminiClient: base_url={self.base_url}, model={self.model}, "
+            f"sample_rate={self.sample_rate}, vertex={self._is_vertex}"
+        )
+
+    def _audio_content_part(self, audio_b64: str) -> dict[str, Any]:
+        return {
+            "type": "input_audio",
+            "input_audio": {"data": audio_b64, "format": "wav"},
+        }
+
+    def _refresh_adc_token(self) -> str:
+        """Mint a fresh OAuth access token from the cached ADC credentials."""
+        if self._adc_credentials is None:
+            raise RuntimeError("_refresh_adc_token called without ADC credentials")
+        request = google.auth.transport.requests.Request()
+        self._adc_credentials.refresh(request)
+        return self._adc_credentials.token
+
+    def _maybe_refresh_token(self) -> None:
+        """Refresh the OpenAI client's bearer token if the ADC token is stale."""
+        if not self._is_vertex or self._adc_credentials is None:
+            return
+        creds = self._adc_credentials
+        needs_refresh = not creds.valid
+        if not needs_refresh and creds.expiry is not None:
+            now = datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+            remaining = (creds.expiry - now).total_seconds()
+            needs_refresh = remaining < TOKEN_REFRESH_MARGIN_SEC
+        if needs_refresh:
+            token = self._refresh_adc_token()
+            self._client.api_key = token
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        """Chat completion against Gemini's OpenAI-compatible endpoint."""
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+
+        last_exception: Exception | None = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                self._maybe_refresh_token()
+                start_time = time.time()
+                response = await self._client.chat.completions.create(**kwargs)
+                elapsed = time.time() - start_time
+
+                message = response.choices[0].message
+                usage = response.usage
+
+                reasoning_tokens = 0
+                if usage and hasattr(usage, "completion_tokens_details"):
+                    details = usage.completion_tokens_details
+                    if details and hasattr(details, "reasoning_tokens"):
+                        reasoning_tokens = getattr(details, "reasoning_tokens", 0) or 0
+
+                stats = {
+                    "prompt_tokens": usage.prompt_tokens if usage else 0,
+                    "completion_tokens": usage.completion_tokens if usage else 0,
+                    "reasoning_tokens": reasoning_tokens,
+                    "finish_reason": response.choices[0].finish_reason or "unknown",
+                    "model": response.model or self.model,
+                    "cost": 0.0,
+                    "cost_source": "gemini_openai_compat",
+                    "latency": round(elapsed, 3),
+                    "reasoning": None,
+                    "reasoning_content": None,
+                }
+
+                if hasattr(message, "tool_calls") and message.tool_calls:
+                    return message, stats
+                return message.content or "", stats
+
+            except Exception as e:
+                last_exception = e
+                if self._is_retryable(e) and attempt < self.max_retries:
+                    delay = self.initial_delay * (2**attempt)
+                    logger.warning(
+                        f"Retryable error (attempt {attempt + 1}/{self.max_retries + 1}): {e}. "
+                        f"Retrying in {delay:.1f}s..."
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                logger.error(f"ALMGeminiClient completion failed: {e}")
+                raise
+
+        raise last_exception  # type: ignore[misc]
+
+    async def transcribe(
+        self,
+        audio_bytes: bytes,
+        source_sample_rate: int,
+        system_prompt: str | None = None,
+    ) -> str | None:
+        """Transcribe a chunk of PCM16 audio via Gemini chat completions."""
+        if not audio_bytes:
+            return None
+
+        prompt = system_prompt or DEFAULT_TRANSCRIPTION_PROMPT
+        user_msg = self.build_audio_user_message(audio_bytes, source_sample_rate)
+        messages = [{"role": "system", "content": prompt}, user_msg]
+
+        try:
+            self._maybe_refresh_token()
+            response = await self._client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                temperature=0.0,
+                max_tokens=self.max_tokens,
+            )
+            text = response.choices[0].message.content if response.choices else None
+            return text.strip() if text else None
+        except Exception as e:
+            logger.error(f"ALMGeminiClient transcription failed: {e}")
+            return None

--- a/src/eva/assistant/pipeline/alm_gemini.py
+++ b/src/eva/assistant/pipeline/alm_gemini.py
@@ -65,7 +65,12 @@ class ALMGeminiClient(BaseALMClient):
         sample_width: int = DEFAULT_SAMPLE_WIDTH,
         project: str | None = None,
         location: str | None = None,
+        thinking_level: str | None = "minimal",
     ):
+        # thinking_level controls Gemini 3 reasoning depth: minimal | low | medium | high.
+        # "minimal" is only supported on Flash / Flash-Lite / Flash-Image variants.
+        # Pass None to omit the field and let the model use its default.
+        self.thinking_level = thinking_level
         super().__init__(
             model=model,
             temperature=temperature,
@@ -121,6 +126,12 @@ class ALMGeminiClient(BaseALMClient):
             "input_audio": {"data": audio_b64, "format": "wav"},
         }
 
+    def _gemini_extra_body(self) -> dict[str, Any]:
+        """Build the `extra_body` payload with Gemini-specific config (thinking, etc.)."""
+        if self.thinking_level is None:
+            return {}
+        return {"google": {"thinking_config": {"thinking_level": self.thinking_level}}}
+
     def _refresh_adc_token(self) -> str:
         """Mint a fresh OAuth access token from the cached ADC credentials."""
         if self._adc_credentials is None:
@@ -155,6 +166,9 @@ class ALMGeminiClient(BaseALMClient):
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
         }
+        extra_body = self._gemini_extra_body()
+        if extra_body:
+            kwargs["extra_body"] = extra_body
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
@@ -167,8 +181,31 @@ class ALMGeminiClient(BaseALMClient):
                 response = await self._client.chat.completions.create(**kwargs)
                 elapsed = time.time() - start_time
 
-                message = response.choices[0].message
+                choice = response.choices[0] if response.choices else None
+                message = choice.message if choice else None
                 usage = response.usage
+                finish_reason = choice.finish_reason if choice else "unknown"
+                if message is None:
+                    # Happens when Gemini's thinking budget consumes all max_tokens
+                    # (finish_reason='length') and no visible message is produced.
+                    logger.warning(
+                        f"Gemini returned no message (finish_reason={finish_reason}). "
+                        f"Consider raising max_tokens or lowering thinking_level."
+                    )
+                    return "", {
+                        "prompt_tokens": usage.prompt_tokens if usage else 0,
+                        "completion_tokens": usage.completion_tokens if usage else 0,
+                        "reasoning_tokens": getattr(
+                            getattr(usage, "completion_tokens_details", None), "reasoning_tokens", 0
+                        ) or 0,
+                        "finish_reason": finish_reason,
+                        "model": response.model or self.model,
+                        "cost": 0.0,
+                        "cost_source": "gemini_openai_compat",
+                        "latency": round(elapsed, 3),
+                        "reasoning": None,
+                        "reasoning_content": None,
+                    }
 
                 reasoning_tokens = 0
                 if usage and hasattr(usage, "completion_tokens_details"):
@@ -180,7 +217,7 @@ class ALMGeminiClient(BaseALMClient):
                     "prompt_tokens": usage.prompt_tokens if usage else 0,
                     "completion_tokens": usage.completion_tokens if usage else 0,
                     "reasoning_tokens": reasoning_tokens,
-                    "finish_reason": response.choices[0].finish_reason or "unknown",
+                    "finish_reason": finish_reason or "unknown",
                     "model": response.model or self.model,
                     "cost": 0.0,
                     "cost_source": "gemini_openai_compat",
@@ -224,12 +261,16 @@ class ALMGeminiClient(BaseALMClient):
 
         try:
             self._maybe_refresh_token()
-            response = await self._client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                temperature=0.0,
-                max_tokens=self.max_tokens,
-            )
+            transcribe_kwargs: dict[str, Any] = {
+                "model": self.model,
+                "messages": messages,
+                "temperature": 0.0,
+                "max_tokens": self.max_tokens,
+            }
+            extra_body = self._gemini_extra_body()
+            if extra_body:
+                transcribe_kwargs["extra_body"] = extra_body
+            response = await self._client.chat.completions.create(**transcribe_kwargs)
             text = response.choices[0].message.content if response.choices else None
             return text.strip() if text else None
         except Exception as e:

--- a/src/eva/assistant/pipeline/alm_gemini.py
+++ b/src/eva/assistant/pipeline/alm_gemini.py
@@ -197,7 +197,8 @@ class ALMGeminiClient(BaseALMClient):
                         "completion_tokens": usage.completion_tokens if usage else 0,
                         "reasoning_tokens": getattr(
                             getattr(usage, "completion_tokens_details", None), "reasoning_tokens", 0
-                        ) or 0,
+                        )
+                        or 0,
                         "finish_reason": finish_reason,
                         "model": response.model or self.model,
                         "cost": 0.0,

--- a/src/eva/assistant/pipeline/alm_vllm.py
+++ b/src/eva/assistant/pipeline/alm_vllm.py
@@ -5,82 +5,25 @@ Provides chat completions with audio content support and audio transcription.
 """
 
 import asyncio
-import base64
-import io
-import struct
 import time
-import wave
 from typing import Any
 
 from openai import AsyncOpenAI
 
+from eva.assistant.pipeline.alm_base import (
+    DEFAULT_NUM_CHANNELS,
+    DEFAULT_SAMPLE_RATE,
+    DEFAULT_SAMPLE_WIDTH,
+    DEFAULT_TRANSCRIPTION_PROMPT,
+    BaseALMClient,
+)
 from eva.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Default audio parameters (Ultravox: 16kHz PCM16 mono)
-DEFAULT_SAMPLE_RATE = 16000
-DEFAULT_NUM_CHANNELS = 1
-DEFAULT_SAMPLE_WIDTH = 2  # 16-bit PCM
 
-VALID_SAMPLE_RATES = {8000, 16000, 24000, 44100, 48000}
-
-
-def pcm16_to_wav_bytes(
-    pcm_data: bytes,
-    sample_rate: int = DEFAULT_SAMPLE_RATE,
-    num_channels: int = DEFAULT_NUM_CHANNELS,
-    sample_width: int = DEFAULT_SAMPLE_WIDTH,
-) -> bytes:
-    """Wrap raw PCM bytes in a WAV container."""
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(num_channels)
-        wf.setsampwidth(sample_width)
-        wf.setframerate(sample_rate)
-        wf.writeframes(pcm_data)
-    return buf.getvalue()
-
-
-def resample_pcm16(pcm_data: bytes, from_rate: int, to_rate: int) -> bytes:
-    """Resample PCM16 mono audio via linear interpolation.
-
-    Args:
-        pcm_data: Raw PCM16 audio bytes.
-        from_rate: Source sample rate in Hz.
-        to_rate: Target sample rate in Hz.
-
-    Returns:
-        Resampled PCM16 bytes at the target rate.
-    """
-    if from_rate == to_rate:
-        return pcm_data
-    num_samples = len(pcm_data) // 2
-    if num_samples == 0:
-        return pcm_data
-    samples = struct.unpack(f"<{num_samples}h", pcm_data)
-    ratio = to_rate / from_rate
-    out_count = int(num_samples * ratio)
-    out_samples = []
-    for i in range(out_count):
-        src_idx = i / ratio
-        idx0 = int(src_idx)
-        idx1 = min(idx0 + 1, num_samples - 1)
-        frac = src_idx - idx0
-        val = int(samples[idx0] * (1 - frac) + samples[idx1] * frac)
-        val = max(-32768, min(32767, val))
-        out_samples.append(val)
-    return struct.pack(f"<{len(out_samples)}h", *out_samples)
-
-
-class ALMvLLMClient:
-    """Client for self-hosted audio language model via vLLM's OpenAI-compatible HTTP API.
-
-    Provides:
-    - complete(): Chat completions with audio content support + tool calling
-    - transcribe(): Audio transcription via chat completion prompt
-    - build_audio_user_message(): Build OpenAI-format message with audio content
-    """
+class ALMvLLMClient(BaseALMClient):
+    """Client for self-hosted audio language model via vLLM's OpenAI-compatible HTTP API."""
 
     def __init__(
         self,
@@ -95,21 +38,20 @@ class ALMvLLMClient:
         num_channels: int = DEFAULT_NUM_CHANNELS,
         sample_width: int = DEFAULT_SAMPLE_WIDTH,
     ):
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            max_retries=max_retries,
+            initial_delay=initial_delay,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            sample_width=sample_width,
+        )
         # Normalize base_url: ensure it ends with /v1 for the OpenAI client
         self.base_url = base_url.rstrip("/")
         if not self.base_url.endswith("/v1"):
             self.base_url = f"{self.base_url}/v1"
-        self.model = model
-        self.temperature = temperature
-        self.max_tokens = max_tokens
-        self.max_retries = max_retries
-        self.initial_delay = initial_delay
-
-        if sample_rate not in VALID_SAMPLE_RATES:
-            raise ValueError(f"Invalid sample_rate={sample_rate}. Must be one of {sorted(VALID_SAMPLE_RATES)}")
-        self.sample_rate = sample_rate
-        self.num_channels = num_channels
-        self.sample_width = sample_width
 
         self._client = AsyncOpenAI(
             base_url=self.base_url,
@@ -123,42 +65,11 @@ class ALMvLLMClient:
             f"sample_width={self.sample_width}"
         )
 
-    def build_audio_user_message(
-        self,
-        audio_bytes: bytes,
-        source_sample_rate: int,
-        text_hint: str = "",
-    ) -> dict[str, Any]:
-        """Build an OpenAI-format user message with audio content.
-
-        Args:
-            audio_bytes: Raw PCM16 audio bytes at source_sample_rate.
-            source_sample_rate: Sample rate of the input audio.
-            text_hint: Optional text to include alongside audio.
-
-        Returns:
-            Message dict with audio_url content for vLLM.
-        """
-        resampled = resample_pcm16(audio_bytes, source_sample_rate, self.sample_rate)
-        wav_bytes = pcm16_to_wav_bytes(
-            resampled,
-            sample_rate=self.sample_rate,
-            num_channels=self.num_channels,
-            sample_width=self.sample_width,
-        )
-        audio_b64 = base64.b64encode(wav_bytes).decode("utf-8")
-
-        content: list[dict[str, Any]] = []
-        if text_hint:
-            content.append({"type": "text", "text": text_hint})
-        content.append(
-            {
-                "type": "audio_url",
-                "audio_url": {"url": f"data:audio/wav;base64,{audio_b64}"},
-            }
-        )
-
-        return {"role": "user", "content": content}
+    def _audio_content_part(self, audio_b64: str) -> dict[str, Any]:
+        return {
+            "type": "audio_url",
+            "audio_url": {"url": f"data:audio/wav;base64,{audio_b64}"},
+        }
 
     async def complete(
         self,
@@ -242,18 +153,30 @@ class ALMvLLMClient:
 
         raise last_exception  # type: ignore[misc]
 
-    @staticmethod
-    def _is_retryable(error: Exception) -> bool:
-        """Check if an error is retryable (connection, timeout, server errors)."""
-        error_str = str(error).lower()
-        retryable_patterns = [
-            "connection",
-            "timeout",
-            "502",
-            "503",
-            "504",
-            "rate limit",
-            "too many requests",
-            "server error",
-        ]
-        return any(pattern in error_str for pattern in retryable_patterns)
+    async def transcribe(
+        self,
+        audio_bytes: bytes,
+        source_sample_rate: int,
+        system_prompt: str | None = None,
+    ) -> str | None:
+        """Transcribe a chunk of PCM16 audio via vLLM chat completions."""
+        if not audio_bytes:
+            return None
+
+        prompt = system_prompt or DEFAULT_TRANSCRIPTION_PROMPT
+        user_msg = self.build_audio_user_message(audio_bytes, source_sample_rate)
+        messages = [{"role": "system", "content": prompt}, user_msg]
+
+        try:
+            response = await self._client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                temperature=0.0,
+                max_tokens=self.max_tokens,
+                extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+            )
+            text = response.choices[0].message.content if response.choices else None
+            return text.strip() if text else None
+        except Exception as e:
+            logger.error(f"ALMvLLMClient transcription failed: {e}")
+            return None

--- a/src/eva/assistant/pipeline/audio_llm_processor.py
+++ b/src/eva/assistant/pipeline/audio_llm_processor.py
@@ -17,15 +17,11 @@ Provides FrameProcessors for the audio-LLM pipeline:
 """
 
 import asyncio
-import base64
-import io
 import time
-import wave
 from collections.abc import Awaitable
 from pathlib import Path
 from typing import Any
 
-from openai import AsyncOpenAI
 from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
@@ -42,11 +38,10 @@ from pipecat.utils.time import time_now_iso8601
 
 from eva.assistant.agentic.audio_llm_system import AudioLLMAgenticSystem
 from eva.assistant.agentic.audit_log import AuditLog
-from eva.assistant.pipeline.alm_vllm import ALMvLLMClient
+from eva.assistant.pipeline.alm_base import DEFAULT_TRANSCRIPTION_PROMPT, BaseALMClient
 from eva.assistant.pipeline.frames import LLMMessageFrame
 from eva.assistant.tools.tool_executor import ToolExecutor
 from eva.models.agents import AgentConfig
-from eva.utils.llm_utils import _resolve_url
 from eva.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -56,9 +51,6 @@ PIPELINE_SAMPLE_RATE = 24000
 
 # Minimum audio size to process (< 10ms of 24kHz 16-bit mono is noise/empty)
 MIN_AUDIO_BYTES = 320
-
-# Round-robin counter for load-balanced transcription URLs
-_transcription_url_counter: int = 0
 
 
 class AudioLLMUserAudioCollector(FrameProcessor):
@@ -174,7 +166,7 @@ class AudioLLMProcessor(FrameProcessor):
         agent: AgentConfig,
         tool_handler: ToolExecutor,
         audit_log: AuditLog,
-        alm_client: ALMvLLMClient,
+        alm_client: BaseALMClient,
         audio_collector: AudioLLMUserAudioCollector,
         output_dir: Path | None = None,
         **kwargs,
@@ -395,35 +387,19 @@ class AudioTranscriptionProcessor(FrameProcessor):
     starts speaking again (interruption). This ensures transcriptions are not lost.
     """
 
-    # Default system prompt for transcription
-    DEFAULT_SYSTEM_PROMPT = """You are an audio transcriber. Your job is to transcribe the input audio to text exactly as it was said by the user.
-
-Rules:
-- Respond with an exact transcription of the audio input only.
-- Do not include any text other than the transcription.
-- Do not explain or add to your response.
-- Transcribe the audio input simply and precisely.
-- If the audio is not clear, respond with exactly: UNCLEAR"""
-
     def __init__(
         self,
         audio_collector: AudioLLMUserAudioCollector,
-        model: str = "",
-        params: dict[str, Any] = None,
+        alm_client: BaseALMClient,
         system_prompt: str | None = None,
         sample_rate: int = PIPELINE_SAMPLE_RATE,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self._audio_collector = audio_collector
-        params = params or {}
-        self._api_key = params["api_key"]
-        self._model = model
-        self._system_prompt = system_prompt or self.DEFAULT_SYSTEM_PROMPT
+        self._alm_client = alm_client
+        self._system_prompt = system_prompt or DEFAULT_TRANSCRIPTION_PROMPT
         self._sample_rate = sample_rate
-        global _transcription_url_counter
-        base_url, _transcription_url_counter = _resolve_url(params, _transcription_url_counter)
-        self._client: AsyncOpenAI = AsyncOpenAI(api_key=self._api_key, base_url=base_url)
 
         # Callback for when transcription is ready (set by pipecat_server.py)
         self.on_transcription: Any | None = None
@@ -499,47 +475,21 @@ Rules:
                 logger.info("No/insufficient audio data for transcription")
                 return None
 
-            # Convert raw PCM to WAV and encode as base64
-            wav_buffer = io.BytesIO()
-            with wave.open(wav_buffer, "wb") as wav_file:
-                wav_file.setnchannels(1)  # Mono
-                wav_file.setsampwidth(2)  # 16-bit
-                wav_file.setframerate(self._sample_rate)
-                wav_file.writeframes(audio_data)
-            wav_buffer.seek(0)
-            audio_b64 = base64.b64encode(wav_buffer.read()).decode("utf-8")
-
-            # Call chat completions with audio input
             start_time = time.time()
-            response = await self._client.chat.completions.create(
-                model=self._model,
-                messages=[
-                    {"role": "system", "content": self._system_prompt},
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "input_audio",
-                                "input_audio": {
-                                    "data": audio_b64,
-                                    "format": "wav",
-                                },
-                            },
-                        ],
-                    },
-                ],
-                extra_body={
-                    "chat_template_kwargs": {
-                        "enable_thinking": False,
-                    }
-                },
+            text = await self._alm_client.transcribe(
+                audio_bytes=audio_data,
+                source_sample_rate=self._sample_rate,
+                system_prompt=self._system_prompt,
             )
             elapsed = time.time() - start_time
-            text = response.choices[0].message.content.strip() if response.choices else "EMPTY"
-            logger.info(f"Transcription from {self._model}: {text}")
+
+            if not text:
+                logger.info(f"Empty transcription (turn_id={turn_id})")
+                return None
+
+            logger.info(f"Transcription from {self._alm_client.model}: {text}")
             logger.debug(f"Elapsed time: {elapsed:.2f}s")
 
-            # Call the callback if set (for transcript saving and audit log update)
             if self.on_transcription and text != "EMPTY":
                 await self.on_transcription(text, timestamp, turn_id)
 

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -44,6 +44,7 @@ from pipecat.transcriptions.language import Language
 from pipecat.utils.text.base_text_filter import BaseTextFilter
 from websockets.asyncio.client import connect as websocket_connect
 
+from eva.assistant.pipeline.alm_gemini import ALMGeminiClient
 from eva.assistant.pipeline.alm_vllm import ALMvLLMClient
 from eva.assistant.pipeline.nvidia_baseten import BasetenSTTService, BasetenTTSService
 from eva.assistant.pipeline.realtime_llm import InstrumentedRealtimeLLMService
@@ -310,10 +311,12 @@ def create_tts_service(
             )
 
         logger.info(f"Using Gemini TTS: {params['model']}")
+        # Supports gemini-2.5-flash-tts, gemini-3.1-flash-tts-preview, etc.
         return GeminiTTSService(
             api_key=api_key,
             model=params["model"],
-            voice_name=params.get("voice_name", "Puck"),
+            voice_id=params.get("voice_id", params.get("voice_name", "Kore")),
+            sample_rate=SAMPLE_RATE,
         )
 
     elif model_lower == "kokoro":
@@ -566,26 +569,55 @@ def get_openai_session_properties(system_prompt: str, params: dict, pipecat_tool
 def create_audio_llm_client(
     model: str,
     params: dict[str, Any],
-) -> ALMvLLMClient:
+) -> ALMvLLMClient | ALMGeminiClient:
     """Create an audio-LLM API client.
 
     Audio-LLM models accept audio input + text context and return text output.
-    Currently supports self-hosted models via vLLM's OpenAI-compatible API.
+    Supports self-hosted models via vLLM's OpenAI-compatible API and Gemini
+    via its OpenAI-compatibility endpoint (e.g. gemini-3-flash-preview).
 
     Args:
-        model: Audio-LLM model identifier (e.g. "vllm").
-        params: Model-specific parameters. Required: url (or urls for round-robin).
-                Optional: api_key, model, temperature, max_tokens,
-                sample_rate, num_channels, sample_width.
+        model: Audio-LLM model identifier (e.g. "vllm", "gemini").
+        params: Model-specific parameters. Required for vLLM: url (or urls).
+                Required for Gemini: api_key, model.
+                Optional: temperature, max_tokens, sample_rate, num_channels, sample_width.
 
     Returns:
-        Configured ALMvLLMClient.
+        Configured audio-LLM client.
     """
     model_lower = model.lower()
 
     # Resolve URL once (supports round-robin via "base_urls" list)
     global _audio_llm_url_counter
     base_url, _audio_llm_url_counter = _resolve_url(params, _audio_llm_url_counter)
+
+    if "gemini" in model_lower:
+        gemini_model = params.get("model", "gemini-3-flash-preview")
+        project = params.get("project")
+        location = params.get("location")
+        api_key = params.get("api_key")
+        if not (project and location) and not api_key:
+            raise ValueError(
+                "Gemini audio-LLM requires either api_key (Developer API) "
+                "or project+location (Vertex AI via GOOGLE_APPLICATION_CREDENTIALS)."
+            )
+        client = ALMGeminiClient(
+            api_key=api_key,
+            base_url=base_url or None,
+            model=gemini_model,
+            temperature=params.get("temperature", 0.0),
+            max_tokens=params.get("max_tokens", 1024),
+            sample_rate=params.get("sample_rate", 16000),
+            num_channels=params.get("num_channels", 1),
+            sample_width=params.get("sample_width", 2),
+            project=project,
+            location=location,
+        )
+        logger.info(
+            f"Using Gemini audio-LLM: {gemini_model} "
+            f"({'vertex' if project and location else 'api_key'})"
+        )
+        return client
 
     if "vllm" in model_lower:
         if not base_url:
@@ -604,7 +636,7 @@ def create_audio_llm_client(
         logger.info(f"Using {model} vLLM audio-LLM: {base_url}")
         return client
 
-    raise ValueError(f"Unknown audio-LLM model: {model}. Available: vllm")
+    raise ValueError(f"Unknown audio-LLM model: {model}. Available: vllm, gemini")
 
 
 async def override_run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -593,7 +593,7 @@ def create_audio_llm_client(
     base_url, _audio_llm_url_counter = _resolve_url(params, _audio_llm_url_counter)
 
     if "gemini" in model_lower:
-        gemini_model = params.get("model", "gemini-3-flash-preview")
+        gemini_model = params["model"]
         project = params.get("project")
         location = params.get("location")
         api_key = params.get("api_key")
@@ -606,13 +606,14 @@ def create_audio_llm_client(
             api_key=api_key,
             base_url=base_url or None,
             model=gemini_model,
-            temperature=params.get("temperature", 0.0),
+            temperature=params.get("temperature", 1.0),
             max_tokens=params.get("max_tokens", 1024),
             sample_rate=params.get("sample_rate", 16000),
             num_channels=params.get("num_channels", 1),
             sample_width=params.get("sample_width", 2),
             project=project,
             location=location,
+            thinking_level=params.get("thinking_level", "minimal"),
         )
         logger.info(f"Using Gemini audio-LLM: {gemini_model} ({'vertex' if project and location else 'api_key'})")
         return client

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -44,6 +44,7 @@ from pipecat.transcriptions.language import Language
 from pipecat.utils.text.base_text_filter import BaseTextFilter
 from websockets.asyncio.client import connect as websocket_connect
 
+from eva.assistant.pipeline.alm_base import BaseALMClient
 from eva.assistant.pipeline.alm_gemini import ALMGeminiClient
 from eva.assistant.pipeline.alm_vllm import ALMvLLMClient
 from eva.assistant.pipeline.nvidia_baseten import BasetenSTTService, BasetenTTSService
@@ -569,7 +570,7 @@ def get_openai_session_properties(system_prompt: str, params: dict, pipecat_tool
 def create_audio_llm_client(
     model: str,
     params: dict[str, Any],
-) -> ALMvLLMClient | ALMGeminiClient:
+) -> BaseALMClient:
     """Create an audio-LLM API client.
 
     Audio-LLM models accept audio input + text context and return text output.

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -614,10 +614,7 @@ def create_audio_llm_client(
             project=project,
             location=location,
         )
-        logger.info(
-            f"Using Gemini audio-LLM: {gemini_model} "
-            f"({'vertex' if project and location else 'api_key'})"
-        )
+        logger.info(f"Using Gemini audio-LLM: {gemini_model} ({'vertex' if project and location else 'api_key'})")
         return client
 
     if "vllm" in model_lower:


### PR DESCRIPTION
Gemini TTS service updated to match new pipecat expectation
2nd service for ALM refactored with parent ALM class
Small bug in run_text_only fixed

Run gemini ALM with:
```
EVA_MODEL__AUDIO_LLM=gemini
EVA_MODEL__AUDIO_LLM_PARAMS='{"api_key": "NOT NEEDED but here for pydantic validation", "project":"project_name","location":"global","model":"gemini-3-flash-preview"}'
GOOGLE_APPLICATION_CREDENTIALS=path
```