### PR TITLE
Change silence turn duration from 15ms to 15s in the user simulator

### DIFF
--- a/docs/experiment_setup.md
+++ b/docs/experiment_setup.md
@@ -130,7 +130,7 @@ Then, use the following configuration:
 | First message                        | None (remove the default first message, as the agent speaks first)                |
 | Interruptible                        | Disabled                                                                          |
 | Advanced > Input audio               | μ-law telephony, 8000 Hz                                                          |
-| Advanced > Take turn after silence   | 15ms                                                                              |
+| Advanced > Take turn after silence   | 15s                                                                              |
 | Advanced > Max conversation duration | 600s                                                                              |
 | Tools > System tools                 | Enable "End conversation" (Name is `end_call`, and Description is provided below) |
 


### PR DESCRIPTION
Correcting a typo in the setup. 

The 11 labs documentation says that "Take turn after silence" is " The maximum number of seconds since the user last spoke. If exceeded, the agent will respond and force a turn." Thus I believe setting it at 15ms is unreasonably short, basically leaving the system under test have no time to respond.