### PR TITLE
Fix speech fidelity intended text with newlines

### DIFF
--- a/src/eva/__init__.py
+++ b/src/eva/__init__.py
@@ -11,4 +11,4 @@ simulation_version = "2.0.0"
 
 # Bump metrics_version when changes affect metric computation (metrics code,
 # judge prompts, pricing tables, postprocessor).
-metrics_version = "2.0.0"
+metrics_version = "2.1.0"

--- a/src/eva/metrics/accuracy/agent_speech_fidelity.py
+++ b/src/eva/metrics/accuracy/agent_speech_fidelity.py
@@ -14,7 +14,7 @@ class AgentSpeechFidelityMetric(SpeechFidelityBaseMetric):
     """
 
     name = "agent_speech_fidelity"
-    version = "v0.1"
+    version = "v0.2"
     description = "Audio-based evaluation of agent speech fidelity to the intended text"
     category = "accuracy"
     role = "assistant"

--- a/src/eva/metrics/accuracy/agent_speech_fidelity_s2s.py
+++ b/src/eva/metrics/accuracy/agent_speech_fidelity_s2s.py
@@ -25,7 +25,7 @@ class AgentSpeechFidelityS2SMetric(SpeechFidelityBaseMetric):
     """
 
     name = "agent_speech_fidelity"
-    version = "v0.1"
+    version = "v0.2"
     description = "Audio-based evaluation of agent entity fidelity for S2S models"
     category = "accuracy"
     role = "assistant"

--- a/src/eva/metrics/speech_fidelity_base.py
+++ b/src/eva/metrics/speech_fidelity_base.py
@@ -387,5 +387,15 @@ class SpeechFidelityBaseMetric(AudioJudgeMetric):
 
     @staticmethod
     def _format_intended_turns(intended_turns: dict[int, str]) -> str:
-        """Format intended turns dictionary as numbered list."""
-        return "\n".join(f"Turn {turn_id}: {text}" for turn_id, text in intended_turns.items())
+        """Format intended turns dictionary as a numbered list, one turn per line.
+
+        Each turn's text is flattened to a single line (internal newlines and
+        repeated whitespace collapsed to single spaces). Turns are separated by
+        newlines, so a turn whose text contains its own newline -- e.g. a normal
+        paragraph break, or a self-duplicated response like "X\nX" -- would
+        otherwise spill onto unlabeled lines and be misread by the judge as a
+        separate turn or an "added" repetition, unfairly penalizing fidelity.
+        Spoken audio has no notion of newlines, so flattening preserves the
+        intended words while keeping turn boundaries unambiguous.
+        """
+        return "\n".join(f"Turn {turn_id}: {' '.join(text.split())}" for turn_id, text in intended_turns.items())

--- a/src/eva/metrics/validation/user_speech_fidelity.py
+++ b/src/eva/metrics/validation/user_speech_fidelity.py
@@ -14,7 +14,7 @@ class UserSpeechFidelityMetric(SpeechFidelityBaseMetric):
     """
 
     name = "user_speech_fidelity"
-    version = "v0.1"
+    version = "v0.2"
     description = "Audio-based validation of user speech fidelity to the intended text"
     category = "validation"
     role = "user"

--- a/tests/fixtures/metric_signatures.json
+++ b/tests/fixtures/metric_signatures.json
@@ -2,14 +2,14 @@
   "AgentSpeechFidelityMetric": {
     "name": "agent_speech_fidelity",
     "prompt_hash": "864be78919d2",
-    "source_hash": "77743114e9b0",
-    "version": "v0.1"
+    "source_hash": "15b21e9c2be1",
+    "version": "v0.2"
   },
   "AgentSpeechFidelityS2SMetric": {
     "name": "agent_speech_fidelity",
     "prompt_hash": "864be78919d2",
-    "source_hash": "5b3deb4968cd",
-    "version": "v0.1"
+    "source_hash": "dbd5868811b2",
+    "version": "v0.2"
   },
   "AuthenticationSuccessMetric": {
     "name": "authentication_success",
@@ -98,7 +98,7 @@
   "UserSpeechFidelityMetric": {
     "name": "user_speech_fidelity",
     "prompt_hash": "c4d97e36b865",
-    "source_hash": "e38e8c162b3d",
-    "version": "v0.1"
+    "source_hash": "cac98a26dcd0",
+    "version": "v0.2"
   }
 }


### PR DESCRIPTION
In the speech fidelity judge prompt, turns are separated by newlines, so a turn whose text contains its own newline would spill onto unlabeled lines and, sometimes, be misread by the judge, unfairly penalizing speech fidelity.

---
For example:
```
Turn 1: Hello,

World!
Turn 2: Nice to meet you, too.
```
The judge could get confused and only expect "Hello".

---
As a concrete example, we noticed some LLMs repeating their output after a newline:
```
Turn 1: Absolutely. I can help with access requests. First, I need to verify your identity with your employee ID and the last four digits of your phone number on file.
Absolutely. I can help with access requests. First, I need to verify your identity with your employee ID and the last four digits of your phone number on file.
```
And the speech fidelity judge made it seem like it was a TTS issue, whereas it was an LLM issue:
> The assistant repeats the entire response twice in the audio, which is a significant deviation from the intended text.

---
Flattening the text to a single line avoids this confusion, and the speech fidelity judge considers the whole text, as expected. Not that, in the example above, this turn is penalized for conciseness, as expected.