### PR TITLE
Add support for Cartesia Ink-2 (semantic endpointing) STT + 16 kHz input-rate fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,14 +64,14 @@ AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key_here
 # --- LLM mode: STT ---
 #i STT provider for the voice pipeline.
 #d enum
-#e assemblyai,cartesia,deepgram,deepgram-flux,elevenlabs,nvidia,nvidia-baseten,openai
+#e assemblyai,cartesia,cartesia-multilingual,deepgram,deepgram-flux,elevenlabs,nvidia,nvidia-baseten,openai
 #x pipeline_mode=LLM
 EVA_MODEL__STT=cartesia
 
 #i STT provider parameters. Must include "api_key" and "model".
 #d json_object
 #x pipeline_mode=LLM
-EVA_MODEL__STT_PARAMS='{"api_key": "your_cartesia_api_key", "model": "ink-whisper"}'
+EVA_MODEL__STT_PARAMS='{"api_key": "your_cartesia_api_key", "model": "ink-2"}'
 
 # --- LLM mode: TTS ---
 #i TTS provider for the voice pipeline.

--- a/docs/experiment_setup.md
+++ b/docs/experiment_setup.md
@@ -73,6 +73,7 @@ The table below lists all the other API-hosted models.
 We use the default turn detection configurations for most framework in our experiments. Each framework offers varying levels of configurability, making it difficult to standardize exact parameters and turn strategies across evaluations.
 
 - **Pipecat.** The default start strategy uses VAD (voice activity detection) or transcription receipt to determine when the user begins speaking, and the stop strategy uses AI-powered turn detection via `LocalSmartTurnAnalyzerV3` to determine when the user finishes speaking.
+- **Cartesia STT.** `EVA_MODEL__STT=cartesia` uses ink-2 self-endpointing and auto-selects `TURN_START_STRATEGY=external`, `TURN_STOP_STRATEGY=external`, and `VAD=none`; `cartesia-multilingual` keeps the ink-whisper VAD/smart-turn path.
 - **OpenAI Realtime.** We use the default server VAD, which uses periods of silence to detect turn boundaries. Default values are used for `threshold`, `prefix_padding_ms`, and `silence_duration`.
 - **ElevenAgents.** The turn "eagerness" parameter was set to `eager`.
 - **Gemini Live.** We use the default automatic VAD provided.

--- a/src/eva/assistant/pipecat_server.py
+++ b/src/eva/assistant/pipecat_server.py
@@ -6,6 +6,7 @@ It handles audio streaming via WebSocket with Twilio-style frame serialization.
 
 import asyncio
 import json
+import time
 from pathlib import Path
 
 import uvicorn
@@ -29,6 +30,7 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.processors.audio.audio_buffer_processor import AudioBufferProcessor
 from pipecat.serializers.twilio import TwilioFrameSerializer
+from pipecat.services.cartesia.turns.stt import CartesiaTurnsSTTService
 from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketParams,
     FastAPIWebsocketTransport,
@@ -282,6 +284,12 @@ class PipecatAssistantServer(AbstractAssistantServer):
                 # Create LLM client for agentic system (separate from Pipecat LLM service)
                 llm_client = LiteLLMClient(model=self.pipeline_config.llm)
 
+                # Self-endpointing STT (Cartesia ink-2): log its turn diagnostics. Turn boundaries
+                # come from the service's own frames via the external strategies (auto-forced in
+                # ModelConfig); these handlers are diagnostics only and do not affect aggregation.
+                if isinstance(stt, CartesiaTurnsSTTService):
+                    self._register_ink2_diagnostics(stt)
+
             # Create context aggregator with user turn strategies
             messages = []
             if realtime_llm:
@@ -480,6 +488,36 @@ class PipecatAssistantServer(AbstractAssistantServer):
                 self._metrics_observer = None
 
             logger.info("Client disconnected from assistant server")
+
+    def _register_ink2_diagnostics(self, stt: CartesiaTurnsSTTService) -> None:
+        """Log Cartesia ink-2 eager-end / resume events and the eager->final latency delta.
+
+        Diagnostics only: ink-2's committed turn boundaries already drive aggregation through the
+        external turn strategies. The eager->final delta quantifies how much earlier the LLM could
+        have started if speculative execution were enabled (a possible future enhancement).
+        """
+        # monotonic seconds at the last eager-end prediction (None if none pending)
+        eager: dict[str, float | None] = {"ts": None}
+
+        @stt.event_handler("on_turn_eager_end")
+        async def _on_eager_end(_service, transcript: str) -> None:
+            eager["ts"] = time.monotonic()
+            logger.info(f"[ink-2] eager end-of-turn predicted: {transcript!r}")
+
+        @stt.event_handler("on_turn_resume")
+        async def _on_resume(_service) -> None:
+            eager["ts"] = None
+            logger.info("[ink-2] turn resumed after eager end (user kept talking)")
+
+        @stt.event_handler("on_turn_end")
+        async def _on_turn_end(_service, transcript: str) -> None:
+            ts = eager["ts"]
+            if ts is not None:
+                delta_ms = int((time.monotonic() - ts) * 1000)
+                logger.info(f"[ink-2] committed end-of-turn (eager->final +{delta_ms}ms): {transcript!r}")
+            else:
+                logger.info(f"[ink-2] committed end-of-turn (no eager prediction): {transcript!r}")
+            eager["ts"] = None
 
     def _create_transport(self, websocket) -> FastAPIWebsocketTransport:
         """Create the WebSocket transport with Twilio frame serialization."""

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -21,6 +21,7 @@ from pipecat.services.assemblyai.stt import (
 )
 from pipecat.services.cartesia.stt import CartesiaLiveOptions, CartesiaSTTService
 from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.cartesia.turns.stt import CartesiaTurnsSTTService
 from pipecat.services.deepgram.flux.stt import DeepgramFluxSTTService
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.deepgram.tts import DeepgramTTSService
@@ -79,7 +80,7 @@ from eva.utils.prompt_manager import PromptManager
 
 logger = get_logger(__name__)
 
-# Default sample rate for audio
+# Default sample rate for audio (TTS output rate).
 SAMPLE_RATE = 24000
 
 # Round-robin counters for load-balanced URLs (one per service type)
@@ -98,7 +99,7 @@ def create_stt_service(
     Based on create_stt_service() from chatbot.py.
 
     Args:
-        model: STT model identifier (deepgram, deepgram-flux, openai, assemblyai, cartesia, nvidia)
+        model: STT model identifier (deepgram, deepgram-flux, openai, assemblyai, cartesia, cartesia-multilingual, nvidia)
         params: Model-specific parameters (may include 'alias' key which is ignored here)
         language_code: Language code for transcription
 
@@ -131,13 +132,24 @@ def create_stt_service(
         )
 
     elif model_lower == "cartesia":
-        logger.info(f"Using Cartesia STT: {params['model']}")
+        # ink-2 provides its own turn boundaries; ModelConfig selects external endpointing.
+        model_name = params.get("model", "ink-2")
+        logger.info(f"Using Cartesia STT (ink-2): {model_name}")
+        return CartesiaTurnsSTTService(
+            api_key=api_key,
+            sample_rate=params.get("sample_rate", 16000),
+            should_interrupt=params.get("should_interrupt", True),
+            settings=CartesiaTurnsSTTService.Settings(model=model_name),
+        )
+
+    elif model_lower == "cartesia-multilingual":
+        logger.info(f"Using Cartesia multilingual STT (ink-whisper): {params['model']}")
         return CartesiaSTTService(
             api_key=api_key,
             live_options=CartesiaLiveOptions(
                 model=params["model"],
                 language=language_code,
-                sample_rate=SAMPLE_RATE,
+                sample_rate=16000,
             ),
         )
 
@@ -237,7 +249,7 @@ def create_stt_service(
 
     else:
         raise ValueError(
-            f"Unknown STT model: {model}. Available: assemblyai, cartesia, cohere, deepgram, deepgram-flux, elevenlabs, nvidia, nvidia-baseten, openai, xai"
+            f"Unknown STT model: {model}. Available: assemblyai, cartesia, cartesia-multilingual, cohere, deepgram, deepgram-flux, elevenlabs, nvidia, nvidia-baseten, openai, xai"
         )
 
 

--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -117,6 +117,10 @@ class ModelConfig(BaseModel):
     }
     _LEGACY_DROP: ClassVar[set[str]] = {"realtime_model", "realtime_model_params"}
 
+    # STT models that perform their own (server-side) semantic endpointing. They drive turn
+    # boundaries themselves, so they must run with the 'external' turn strategies and no local VAD.
+    _SELF_ENDPOINTING_STT: ClassVar[set[str]] = {"cartesia"}
+
     # ── Mode selectors (exactly one group must be set for a real run) ──
     llm: str | None = Field(
         None,
@@ -229,6 +233,34 @@ class ModelConfig(BaseModel):
         for key in cls._LEGACY_DROP:
             data.pop(key, None)
         return data
+
+    @model_validator(mode="after")
+    def _autowire_self_endpointing_stt(self) -> "ModelConfig":
+        """Auto-configure turn-taking for self-endpointing STT models (e.g. Cartesia ink-2).
+
+        These models drive turn boundaries themselves (the service pushes its own speech
+        start/stop and transcription frames), so they require the 'external' turn strategies
+        with local VAD disabled. Forcing it here lets a bare ``EVA_MODEL__STT=cartesia``
+        "just work", and the forced values are reflected in the persisted config.json / run_id.
+        A conflicting user-provided value is overridden with a WARNING; an untouched default is
+        logged at INFO. Idempotent: a value already at the target is left untouched (clean reload).
+        """
+        if (self.stt or "").lower() not in self._SELF_ENDPOINTING_STT:
+            return self
+
+        forced = {"turn_start_strategy": "external", "turn_stop_strategy": "external", "vad": "none"}
+        for field, target in forced.items():
+            if getattr(self, field) == target:
+                continue
+            if field in self.model_fields_set:
+                logger.warning(
+                    f"STT '{self.stt}' performs its own endpointing; overriding "
+                    f"{field}='{getattr(self, field)}' -> '{target}'."
+                )
+            else:
+                logger.info(f"STT '{self.stt}': auto-setting {field}='{target}' (self-endpointing).")
+            setattr(self, field, target)
+        return self
 
 
 class PipelineType(StrEnum):

--- a/tests/unit/assistant/test_services.py
+++ b/tests/unit/assistant/test_services.py
@@ -74,9 +74,41 @@ class TestCreateSttService:
         svc = create_stt_service("openai", params={"api_key": "k", "model": "whisper-2"})
         assert svc._settings.model == "whisper-2"
 
-    def test_cartesia_service_created(self):
-        svc = create_stt_service("cartesia", params={"api_key": "k", "model": "ink"})
-        assert "Cartesia" in type(svc).__name__
+    def test_cartesia_is_ink2_turns_service(self):
+        svc = create_stt_service("cartesia", params={"api_key": "k", "model": "ink-2"})
+        assert "Turns" in type(svc).__name__
+
+    def test_cartesia_defaults_to_ink2(self):
+        svc = create_stt_service("cartesia", params={"api_key": "k"})
+        assert svc._settings.model == "ink-2"
+
+    def test_cartesia_multilingual_is_ink_whisper(self):
+        svc = create_stt_service("cartesia-multilingual", params={"api_key": "k", "model": "ink-whisper"})
+        assert "Cartesia" in type(svc).__name__ and "Turns" not in type(svc).__name__
+
+    def test_unknown_stt_error_lists_cartesia_multilingual_and_xai(self):
+        with pytest.raises(ValueError, match="Unknown STT model") as exc:
+            create_stt_service("bogus", params={"api_key": "k"})
+        msg = str(exc.value)
+        assert "cartesia-multilingual" in msg
+        assert "xai" in msg
+
+
+_CARTESIA_STT_PROVIDERS = [
+    ("cartesia", {"api_key": "k", "model": "ink-2"}),
+    ("cartesia-multilingual", {"api_key": "k", "model": "ink-whisper"}),
+]
+
+
+class TestCartesiaSttInputSampleRate:
+    @pytest.mark.parametrize("provider,params", _CARTESIA_STT_PROVIDERS)
+    def test_cartesia_stt_declares_16khz_input(self, provider, params):
+        svc = create_stt_service(provider, params=params)
+        assert svc._init_sample_rate == 16000
+
+    def test_cartesia_caller_can_override_sample_rate(self):
+        svc = create_stt_service("cartesia", params={"api_key": "k", "model": "ink-2", "sample_rate": 8000})
+        assert svc._init_sample_rate == 8000
 
 
 class TestCreateTtsService:

--- a/tests/unit/models/test_config_models.py
+++ b/tests/unit/models/test_config_models.py
@@ -9,7 +9,7 @@ import pytest
 from pydantic import ValidationError
 from pydantic_settings import SettingsError
 
-from eva.models.config import PipelineType, RunConfig
+from eva.models.config import ModelConfig, PipelineType, RunConfig
 
 MODEL_LIST = [
     {
@@ -779,6 +779,53 @@ class TestTurnStrategyConfig:
         assert config.model.turn_stop_strategy == "turn_analyzer"
         assert config.model.vad == "silero"
         assert config.model.vad_params == {}
+
+
+class TestSelfEndpointingSTTAutowire:
+    def test_cartesia_forces_external_and_no_vad(self):
+        m = ModelConfig(stt="cartesia", llm="gpt-5.2")
+        assert m.turn_start_strategy == "external"
+        assert m.turn_stop_strategy == "external"
+        assert m.vad == "none"
+
+    def test_conflicting_user_values_are_overridden(self):
+        m = ModelConfig(
+            stt="cartesia",
+            llm="gpt-5.2",
+            vad="silero",
+            turn_start_strategy="vad",
+            turn_stop_strategy="turn_analyzer",
+        )
+        assert (m.turn_start_strategy, m.turn_stop_strategy, m.vad) == ("external", "external", "none")
+
+    def test_non_self_endpointing_stt_untouched(self):
+        m = ModelConfig(stt="cartesia-multilingual", llm="gpt-5.2")
+        assert (m.turn_start_strategy, m.turn_stop_strategy, m.vad) == ("vad", "turn_analyzer", "silero")
+
+    def test_persisted_config_roundtrip_is_stable(self):
+        m = ModelConfig(
+            stt="cartesia",
+            llm="gpt-5.2",
+            turn_start_strategy="external",
+            turn_stop_strategy="external",
+            vad="none",
+        )
+        assert (m.turn_start_strategy, m.turn_stop_strategy, m.vad) == ("external", "external", "none")
+
+    def test_runconfig_roundtrip(self):
+        c = _config(
+            env_vars=_BASE_ENV
+            | {
+                "EVA_MODEL__STT": "cartesia",
+                "EVA_MODEL__STT_PARAMS": json.dumps({"api_key": "k", "model": "ink-2"}),
+            }
+        )
+        assert c.model.stt == "cartesia"
+        assert (c.model.turn_start_strategy, c.model.turn_stop_strategy, c.model.vad) == (
+            "external",
+            "external",
+            "none",
+        )
 
 
 class TestApiKeyRedactionInPipelineModels:


### PR DESCRIPTION
## Changes

This PR updates the Cartesia STT path used by the cascade benchmark. `EVA_MODEL__STT=cartesia` now uses Cartesia ink-2, while the previous ink-whisper path remains available as `EVA_MODEL__STT=cartesia-multilingual`.

It also fixes the sample rate declared to Cartesia STT services. The pipeline feeds 16 kHz input audio, so Cartesia STT now declares 16 kHz by default while still allowing an explicit `sample_rate` override in `EVA_MODEL__STT_PARAMS`.

The ink-2 path is self-endpointing, so selecting `cartesia` automatically uses external turn start and stop strategies and disables local VAD. The Pipecat server logs ink-2 turn diagnostics, but those diagnostics do not change aggregation behavior.

## Testing

A useful validation is to run a small cascade evaluation with `EVA_MODEL__STT=cartesia` and `EVA_MODEL__STT_PARAMS='{"api_key":"...","model":"ink-2"}'`, then confirm that the resolved config uses external turn start and stop strategies with `VAD=none`.