### PR TITLE
Small adjustments for multilang services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -266,26 +266,13 @@ EVA_MODEL_LIST='[
 #x EVA_LANGUAGE=fr
 #v EVA_FR_USER_M=
 
-#i ElevenLabs agent ID — English, female voice.
+#i ElevenLabs agent ID — English (default), female voice.
 #d string
-#x perturbation_mode=Language
-#x EVA_LANGUAGE=en
-#v EVA_EN_USER_F=
+EVA_EN_USER_F=your_elevenlabs_agent_id_for_default_user_f
 
-#i ElevenLabs agent ID — English, male voice.
+#i ElevenLabs agent ID — English (default), male voice.
 #d string
-#x perturbation_mode=Language
-#x EVA_LANGUAGE=en
-#v EVA_EN_USER_M=
-
-# --- Default user simulator agents ---
-#i ElevenLabs agent ID for the default female-voice user persona.
-#d string
-EVA_DEFAULT_USER_F=your_elevenlabs_agent_id_for_default_user_f
-
-#i ElevenLabs agent ID for the default male-voice user persona.
-#d string
-EVA_DEFAULT_USER_M=your_elevenlabs_agent_id_for_default_user_m
+EVA_EN_USER_M=your_elevenlabs_agent_id_for_default_user_m
 
 # --- Perturbations ---
 # accent and behavior are MUTUALLY EXCLUSIVE (each claims the agent ID slot).

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,33 +2,48 @@
 # Multi-stage build for smaller final image
 
 # ============================================
-# Stage 1: Builder
+# Stage 1: Deps — only rebuilds when pyproject.toml changes
 # ============================================
-FROM python:3.11-slim AS builder
+FROM python:3.11-slim AS deps
 
 WORKDIR /app
 
-# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies — cached as long as pyproject.toml doesn't change
 COPY pyproject.toml README.md ./
-# Stub src so hatchling can resolve the package during dep install
+# Stub src so hatchling can build the package metadata
 RUN mkdir -p src/eva && echo '__version__ = "0.0.0"' > src/eva/__init__.py
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir .
 
-# Copy real source and reinstall only the package (deps already cached above)
+# ============================================
+# Stage 2: Builder — reinstalls only the eva package on source changes
+# ============================================
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bring in the heavy deps venv from stage 1 (cached, ~1GB, only busts on pyproject.toml changes)
+COPY --from=deps /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy real source and reinstall only the eva package (no deps, ~seconds)
+COPY pyproject.toml README.md ./
 COPY src/ ./src/
 RUN pip install --no-cache-dir --no-deps .
 
 # ============================================
-# Stage 2: Runtime
+# Stage 3: Runtime
 # ============================================
 FROM python:3.11-slim AS runtime
 
@@ -51,9 +66,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy virtual environment from builder
-COPY --from=builder /opt/venv /opt/venv
+# Copy deps venv separately so it stays cached when only source changes
+COPY --from=deps /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
+
+# Overlay only the eva package files that changed (tiny, ~seconds to copy)
+COPY --from=builder /opt/venv/lib/python3.11/site-packages/eva /opt/venv/lib/python3.11/site-packages/eva
+COPY --from=builder /opt/venv/bin/eva /opt/venv/bin/eva
 
 # Copy application code
 COPY src/ ./src/

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The editor covers all variables grouped by tab (API keys, voice pipeline, model 
 
 ### Adding a Language
 
-**1. Run `add_culture_data.py`** — handles all one-time setup: generates culturally appropriate names and translated utterances for every dataset record, writes a "respond in X" addendum to `configs/agents/language_addenda.yaml`, translates the assistant's opening greeting into `configs/agents/initial_messages.yaml`, generates a WER normalizer config, and patches `.env.example` with the new agent ID stubs.
+**1. Run `add_culture_data.py`** — handles all one-time setup: generates culturally appropriate names and translated utterances for every dataset record, translates the assistant's opening greeting into `configs/agents/initial_messages.yaml`, generates a WER normalizer config, and patches `.env.example` with the new agent ID stubs.
 
 ```bash
 PYTHONPATH=src python scripts/add_culture_data.py \

--- a/configs/agents/itsm_agent.yaml
+++ b/configs/agents/itsm_agent.yaml
@@ -143,7 +143,7 @@ instructions: |
 
   For desk and parking assignments, always check availability first. If nothing is available in the caller's preferred building or zone, offer to place them on the waitlist. Do not add the same caller to the same waitlist twice.
 
-  Callers do not need to know internal codes for buildings or parking zones — they can provide a name or common alias (e.g., "the downtown building", "Executive Garage", "East Campus"). The system resolves the name to the canonical code, which you should read back to confirm. If a name does not resolve, ask the caller to clarify or offer a short list of known options from the error message.
+  Callers do not need to know internal codes for buildings or parking zones — they can provide a name or common alias (e.g., "the downtown building", "Executive Garage", "동부 캠퍼스") in any language. The system resolves the name to the canonical code, which you should read back to confirm. If a name does not resolve, ask the caller to clarify or offer a short list of known options from the error message.
 
   Reassignment cooldowns: desk reassignments are limited to once per 90 days and parking reassignments to once per 180 days, measured from the most recent prior assignment. If a request is denied because the cooldown has not elapsed, explain the restriction and the next eligible date — do not retry.
 

--- a/src/eva/assistant/pipeline/alm_vllm.py
+++ b/src/eva/assistant/pipeline/alm_vllm.py
@@ -37,6 +37,7 @@ class ALMvLLMClient(BaseALMClient):
         num_channels: int = DEFAULT_NUM_CHANNELS,
         sample_width: int = DEFAULT_SAMPLE_WIDTH,
         language: str | None = None,
+        enable_thinking: bool = False,
     ):
         super().__init__(
             model=model,
@@ -49,6 +50,7 @@ class ALMvLLMClient(BaseALMClient):
             sample_width=sample_width,
             language=language,
         )
+        self.enable_thinking = enable_thinking
         # Normalize base_url: ensure it ends with /v1 for the OpenAI client
         self.base_url = base_url.rstrip("/")
         if not self.base_url.endswith("/v1"):
@@ -92,7 +94,7 @@ class ALMvLLMClient(BaseALMClient):
             "max_tokens": self.max_tokens,
             "extra_body": {
                 "chat_template_kwargs": {
-                    "enable_thinking": False,
+                    "enable_thinking": self.enable_thinking,
                 }
             },
         }
@@ -149,7 +151,7 @@ class ALMvLLMClient(BaseALMClient):
                     await asyncio.sleep(delay)
                     continue
                 else:
-                    logger.error(f"UltravoxVLLM completion failed: {e}")
+                    logger.error(f"VLLM completion failed: {e}")
                     raise
 
         raise last_exception  # type: ignore[misc]

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -176,7 +176,10 @@ def create_stt_service(
             flux_settings_kwargs: dict[str, Any] = {"model": params["model"]}
             # Flux ignores `language`; only `flux-general-multi` honors `language_hints`.
             if params["model"] == "flux-general-multi":
-                flux_settings_kwargs["language_hints"] = [_to_language_enum(language_code)]
+                if params.get("language_hints"):
+                    flux_settings_kwargs["language_hints"] = params["language_hints"]
+                else:
+                    logger.warning("No Language hint provided. Auto detecting language for Deepgram Flux")
             return DeepgramFluxSTTService(
                 api_key=api_key,
                 sample_rate=SAMPLE_RATE,
@@ -391,7 +394,7 @@ def create_tts_service(
         supported = ["en-us", "en-gb", "es", "fr-fr", "hi", "it", "pt-br", "ja", "zh"]
         if language_code not in supported:
             logger.warning(f"Language code {language_code} not supported by Kokoro, trying to convert to 4 char code")
-            two_to_four = {"en": "en-us", "fr": "fr-fr", "pt": "pt-br"}
+            two_to_four = {"en": "en-us", "fr": "fr-fr", "fr-CA": "fr-fr", "pt": "pt-br"}
             language_code = two_to_four.get(language_code, language_code)
             if language_code not in supported:
                 raise ValueError(f"Language code {language_code} not supported by Kokoro")

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -18,7 +18,7 @@ from pipecat.frames.frames import (
 from pipecat.services.assemblyai.stt import AssemblyAISTTService
 from pipecat.services.cartesia.stt import CartesiaSTTService
 from pipecat.services.cartesia.tts import CartesiaTTSService
-from pipecat.services.deepgram.flux.stt import DeepgramFluxSTTService
+from pipecat.services.deepgram.flux.stt import DeepgramFluxSTTService, DeepgramFluxSTTSettings
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.deepgram.tts import DeepgramTTSService
 from pipecat.services.elevenlabs.stt import CommitStrategy, ElevenLabsRealtimeSTTService
@@ -39,6 +39,7 @@ from pipecat.services.stt_service import STTService
 from pipecat.services.tts_service import TTSService
 from pipecat.services.xai.stt import XAISTTService
 from pipecat.services.xai.tts import XAITTSService
+from pipecat.transcriptions.language import Language
 from pipecat.utils.text.base_text_filter import BaseTextFilter
 from websockets.asyncio.client import connect as websocket_connect
 
@@ -87,6 +88,18 @@ def _base_language(tag: str) -> str:
     return tag.split("-")[0].split("_")[0]
 
 
+def _to_language_enum(tag: str) -> Language:
+    """Convert a BCP 47 tag to a pipecat Language enum.
+
+    Tries the full tag first, falls back to the base code (e.g. 'fr-CA' → 'fr').
+    Used for pipecat-native services whose Settings accept Language enum values.
+    """
+    try:
+        return Language(tag)
+    except ValueError:
+        return Language(_base_language(tag))
+
+
 # Round-robin counters for load-balanced URLs (one per service type)
 _tts_url_counter: int = 0
 _stt_url_counter: int = 0
@@ -130,7 +143,7 @@ def create_stt_service(
             api_key=api_key,
             sample_rate=SAMPLE_RATE,
             settings=AssemblyAISTTService.Settings(
-                language=language_code,
+                language=_to_language_enum(language_code),
                 model=params["model"],
             ),
         )
@@ -142,7 +155,7 @@ def create_stt_service(
             sample_rate=SAMPLE_RATE,
             settings=CartesiaSTTService.Settings(
                 model=params["model"],
-                language=language_code,
+                language=_to_language_enum(language_code),
             ),
         )
 
@@ -160,16 +173,20 @@ def create_stt_service(
         # Check if using Flux model
         if "flux" in model_lower:
             logger.info(f"Using Deepgram Flux STT: {params['model']}")
+            flux_settings_kwargs: dict[str, Any] = {"model": params["model"]}
+            # Flux ignores `language`; only `flux-general-multi` honors `language_hints`.
+            if params["model"] == "flux-general-multi":
+                flux_settings_kwargs["language_hints"] = [_to_language_enum(language_code)]
             return DeepgramFluxSTTService(
                 api_key=api_key,
-                model=params["model"],
                 sample_rate=SAMPLE_RATE,
+                settings=DeepgramFluxSTTSettings(**flux_settings_kwargs),
             )
         logger.info(f"Using Deepgram STT: {params['model']}")
         return DeepgramSTTService(
             api_key=api_key,
             settings=DeepgramSTTService.Settings(
-                language=language_code,
+                language=_to_language_enum(language_code),
                 model=params["model"],
                 interim_results=True,
             ),
@@ -183,7 +200,7 @@ def create_stt_service(
             sample_rate=SAMPLE_RATE,
             commit_strategy=CommitStrategy.VAD,
             settings=ElevenLabsRealtimeSTTService.Settings(
-                language=language_code,
+                language=_to_language_enum(language_code),
             ),
         )
 
@@ -238,7 +255,7 @@ def create_stt_service(
             sample_rate=params.get("sample_rate", 16000),
             encoding=params.get("encoding", "pcm"),
             settings=XAISTTService.Settings(
-                language=language_code,
+                language=_to_language_enum(language_code),
                 interim_results=params.get("interim_results", True),
                 endpointing=params.get("endpointing", 200),
             ),
@@ -290,7 +307,7 @@ def create_tts_service(
             settings=CartesiaTTSService.Settings(
                 model=params["model"],
                 voice=params.get("voice_id", "f786b574-daa5-4673-aa0c-cbe3e8534c02"),
-                language=language_code,
+                language=_to_language_enum(language_code),
             ),
         )
 
@@ -320,19 +337,24 @@ def create_tts_service(
             settings=DeepgramTTSService.Settings(
                 model=params["model"],
                 voice=params.get("voice", "aura-2-helena-en"),
-                language=language_code,
+                language=_to_language_enum(language_code),
             ),
         )
 
     elif model_lower == "elevenlabs":
         logger.info(f"Using ElevenLabs TTS: {params['model']}")
+        if (
+            params["model"] not in ("eleven_multilingual_v2", "eleven_flash_v2_5", "eleven_turbo_v2_5")
+            and language_code != "en"
+        ):
+            raise ValueError(f"ElevenLabs model {params['model']} only supports English language")
         return ElevenLabsTTSService(
             api_key=api_key,
             sample_rate=SAMPLE_RATE,
             settings=ElevenLabsTTSService.Settings(
                 model=params["model"],
                 voice=params.get("voice_id", "hpp4J3VqNfWAUOO0d1Us"),
-                language=language_code,
+                language=_to_language_enum(language_code),
             ),
         )
 
@@ -351,7 +373,7 @@ def create_tts_service(
             settings=GeminiTTSService.Settings(
                 model=params["model"],
                 voice=params.get("voice_id", params.get("voice_name", "Kore")),
-                language=language_code,
+                language=_to_language_enum(language_code),
             ),
         )
 
@@ -438,7 +460,7 @@ def create_tts_service(
             codec=params.get("codec", "pcm"),
             settings=XAITTSService.Settings(
                 voice=params.get("voice", "eve"),
-                language=language_code,
+                language=_to_language_enum(language_code),
             ),
         )
         _orig_build_url = xai_tts._build_url

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -749,6 +749,7 @@ def create_audio_llm_client(
             num_channels=params.get("num_channels", 1),
             sample_width=params.get("sample_width", 2),
             language=language,
+            enable_thinking=params.get("enable_thinking", False),
         )
         logger.info(f"Using {model} vLLM audio-LLM: {base_url}")
         return client

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -355,7 +355,7 @@ def create_tts_service(
             settings=ElevenLabsTTSService.Settings(
                 model=params["model"],
                 voice=params.get("voice_id", "hpp4J3VqNfWAUOO0d1Us"),
-                language=_to_language_enum(language_code),
+                language=_base_language(language_code),
             ),
         )
 

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -194,13 +194,14 @@ def create_stt_service(
         )
 
     elif model_lower == "elevenlabs":
-        logger.info("Using ElevenLabs STT")
+        logger.info(f"Using ElevenLabs STT {params['model']}")
         return ElevenLabsRealtimeSTTService(
             api_key=api_key,
             sample_rate=SAMPLE_RATE,
             commit_strategy=CommitStrategy.VAD,
             settings=ElevenLabsRealtimeSTTService.Settings(
-                language=_to_language_enum(language_code),
+                language=_base_language(language_code),
+                model=params["model"],
             ),
         )
 

--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -313,7 +313,7 @@ class PerturbationConfig(BaseModel):
     - connection_degradation: stacks codec artifacts, packet loss, and volume fluctuation on top
 
     Agent ID env vars follow the pattern EVA_{TYPE}_USER_F / EVA_{TYPE}_USER_M.
-    Default (no accent/behavior): EVA_DEFAULT_USER_F and EVA_DEFAULT_USER_M.
+    Default (no accent/behavior): EVA_EN_USER_F and EVA_EN_USER_M (language defaults to English).
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/src/eva/models/record.py
+++ b/src/eva/models/record.py
@@ -117,13 +117,13 @@ class EvaluationRecord(BaseModel):
 
     scenario_context: dict = Field(..., description="Scenario context for the record")
 
-    culture_overrides: dict[str, dict[str, str]] = Field(
+    culture_overrides: dict[str, dict[str, str | dict]] = Field(
         default_factory=dict,
-        description="Per-language name pairs (first_name/last_name) substituted into <FIRST_NAME>/<LAST_NAME>",
+        description="Per-language name/phone/companion pairs substituted into placeholders",
     )
-    romanized_culture_overrides: dict[str, dict[str, str]] = Field(
+    romanized_culture_overrides: dict[str, dict[str, str | dict]] = Field(
         default_factory=dict,
-        description="Per-language ASCII-romanized name pairs for <FIRST_NAME_ROMANIZED>/<LAST_NAME_ROMANIZED> (used in emails)",
+        description="Per-language ASCII-romanized name/companion pairs for romanized placeholders",
     )
     starting_utterances: dict[str, str] = Field(
         default_factory=dict,

--- a/src/eva/user_simulator/client.py
+++ b/src/eva/user_simulator/client.py
@@ -219,16 +219,15 @@ class UserSimulator:
             # ElevenLabs user simulator agent ID
             persona_id = self.persona_config["user_persona_id"]
             gender = _PERSONA_GENDER[persona_id]
-            if self._language and self._language.lower() != "en":
-                env_var = f"EVA_{self._language.upper().replace('-', '_')}_USER_{gender}"
-            elif self._perturbation_config and self._perturbation_config.accent:
+            if self._perturbation_config and self._perturbation_config.accent:
                 key = self._perturbation_config.accent.value.upper()
                 env_var = f"EVA_{key}_ACCENT_USER_{gender}"
             elif self._perturbation_config and self._perturbation_config.behavior:
                 key = self._perturbation_config.behavior.value.upper()
                 env_var = f"EVA_{key}_USER_{gender}"
             else:
-                env_var = f"EVA_DEFAULT_USER_{gender}"
+                lang = (self._language or "en").upper().replace("-", "_")
+                env_var = f"EVA_{lang}_USER_{gender}"
             ELEVENLABS_USER_AGENT_ID = os.getenv(env_var)
             logger.info(f"Using agent ID from env var: {env_var}")
 

--- a/src/eva/utils/culture.py
+++ b/src/eva/utils/culture.py
@@ -39,8 +39,8 @@ _LANGUAGE_ADDENDUM_TEMPLATE = (
     " which may be in non-ascii, native script. You may need to try both scripts when"
     " looking up by name. All translatable values should be translated when talking to"
     " the user. For example, if you are telling the user about a location from a tool"
-    " response which says 'downtown', this should be translated. Distinct item names (e.g."
-    " 'IntelliJ') should be kept in their original form."
+    " response which says 'Downtown' or 'West Laboratory', this should be translated. Only"
+    " distinct item names (e.g. 'IntelliJ') should be kept in their original form."
 )
 
 FIRST_NAME_PLACEHOLDER = "<FIRST_NAME>"
@@ -199,7 +199,7 @@ def add_user_language_directive(language: str, language_display_name: str, user_
     directive = (
         f"Speak ONLY in {language_display_name}. Do not switch to English even if the agent does. "
         "All translatable values should be translated when talking to the agent. "
-        "For example, if you are telling the agent about a location like 'downtown office' and you are speaking Spanish, say 'oficina del centro'. "
+        "For example, if you are telling the agent about a location like 'Downtown Office' and you are speaking Spanish, say 'oficina del centro'. "
         "If you are talking about a date that you read as MM/DD/YYYY, you should say it in the culturally appropriate format. "
         "Distinct proper names (e.g. 'IntelliJ', 'Google') should be kept in their original form."
     )


### PR DESCRIPTION
Using the enum instead of the string allows pipecat to auto resolve some of the name formats for languages.

Added support for Deepgram Flux Language param

Updated Dockerfile for better iteration (push size goes down to 50mb from 1.2gb when we change the local source)

Update pydantic config to support our airline traveling companion. (One record, a woman calls about her husband, and he needs cultural naming as well from the earlier multilingual PR)

Remove default user and instead use en user

update readme to be more accurate 

Fix ALM parameter for thinking hard coded to False