### PR TITLE
Support extra provider-specific STT and TTS params

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,8 @@ EVA_MODEL__LLM=gpt-5.2
 #x pipeline_mode=LLM
 EVA_MODEL__STT=cartesia
 
-#i STT provider parameters. Must include "api_key" and "model".
+#i STT provider parameters. Must include "api_key" and "model". Use "urls" for round-robin load balancing.
+#i Some providers also accept extra provider-specific tuning parameters here.
 #d json_object
 #x pipeline_mode=LLM
 EVA_MODEL__STT_PARAMS='{"api_key": "your_cartesia_api_key", "model": "ink-whisper"}'
@@ -85,7 +86,8 @@ EVA_MODEL__STT_PARAMS='{"api_key": "your_cartesia_api_key", "model": "ink-whispe
 #x pipeline_mode=LLM,AudioLLM
 EVA_MODEL__TTS=cartesia
 
-#i TTS provider parameters. Must include "api_key" and "model". Use "urls" for round-robin load balancing.
+#i TTS provider parameters. Must include "api_key" and "model". Use "urls" for round-robin load balancing, and "voice_id" to select a voice.
+#i Some providers also accept extra provider-specific tuning parameters here.
 #d json_object
 #x pipeline_mode=LLM,AudioLLM
 EVA_MODEL__TTS_PARAMS='{"api_key": "your_cartesia_api_key", "model": "sonic"}'

--- a/src/eva/assistant/pipeline/services.py
+++ b/src/eva/assistant/pipeline/services.py
@@ -3,6 +3,7 @@
 Creates Pipecat services with proper configuration.
 """
 
+import dataclasses
 import datetime
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -139,12 +140,15 @@ def create_stt_service(
 
     if model_lower == "assemblyai":
         logger.info(f"Using AssemblyAI STT: {params['model']}")
+        assemblyai_settings_kwargs = {
+            k: params[k] for f in dataclasses.fields(AssemblyAISTTService.Settings) if (k := f.name) in params
+        }
         return AssemblyAISTTService(
             api_key=api_key,
             sample_rate=SAMPLE_RATE,
             settings=AssemblyAISTTService.Settings(
                 language=_to_language_enum(language_code),
-                model=params["model"],
+                **assemblyai_settings_kwargs,
             ),
         )
 
@@ -186,25 +190,31 @@ def create_stt_service(
                 settings=DeepgramFluxSTTSettings(**flux_settings_kwargs),
             )
         logger.info(f"Using Deepgram STT: {params['model']}")
+        deepgram_settings_kwargs = {
+            k: params[k] for f in dataclasses.fields(DeepgramSTTService.Settings) if (k := f.name) in params
+        }
+        deepgram_settings_kwargs.setdefault("interim_results", True)
         return DeepgramSTTService(
             api_key=api_key,
             settings=DeepgramSTTService.Settings(
                 language=_to_language_enum(language_code),
-                model=params["model"],
-                interim_results=True,
+                **deepgram_settings_kwargs,
             ),
             sample_rate=SAMPLE_RATE,
         )
 
     elif model_lower == "elevenlabs":
         logger.info(f"Using ElevenLabs STT {params['model']}")
+        elevenlabs_settings_kwargs = {
+            k: params[k] for f in dataclasses.fields(ElevenLabsRealtimeSTTService.Settings) if (k := f.name) in params
+        }
         return ElevenLabsRealtimeSTTService(
             api_key=api_key,
             sample_rate=SAMPLE_RATE,
             commit_strategy=CommitStrategy.VAD,
             settings=ElevenLabsRealtimeSTTService.Settings(
                 language=_base_language(language_code),
-                model=params["model"],
+                **elevenlabs_settings_kwargs,
             ),
         )
 
@@ -254,14 +264,18 @@ def create_stt_service(
 
     elif model_lower == "xai":
         logger.info("Using xAI STT")
+        xai_settings_kwargs = {
+            k: params[k] for f in dataclasses.fields(XAISTTService.Settings) if (k := f.name) in params
+        }
+        xai_settings_kwargs.setdefault("interim_results", True)
+        xai_settings_kwargs.setdefault("endpointing", 200)
         return XAISTTService(
             api_key=api_key,
             sample_rate=params.get("sample_rate", 16000),
             encoding=params.get("encoding", "pcm"),
             settings=XAISTTService.Settings(
                 language=_to_language_enum(language_code),
-                interim_results=params.get("interim_results", True),
-                endpointing=params.get("endpointing", 200),
+                **xai_settings_kwargs,
             ),
         )
 
@@ -304,14 +318,17 @@ def create_tts_service(
 
     if model_lower == "cartesia":
         logger.info(f"Using Cartesia TTS: {params['model']}")
+        cartesia_settings_kwargs = {
+            k: params[k] for f in dataclasses.fields(CartesiaTTSService.Settings) if (k := f.name) in params
+        }
         return CartesiaTTSService(
             url=url or "wss://api.cartesia.ai/tts/websocket",
             api_key=api_key,
             sample_rate=SAMPLE_RATE,
             settings=CartesiaTTSService.Settings(
-                model=params["model"],
                 voice=params.get("voice_id", "f786b574-daa5-4673-aa0c-cbe3e8534c02"),
                 language=_to_language_enum(language_code),
+                **cartesia_settings_kwargs,
             ),
         )
 
@@ -352,13 +369,16 @@ def create_tts_service(
             and language_code != "en"
         ):
             raise ValueError(f"ElevenLabs model {params['model']} only supports English language")
+        elevenlabs_settings_kwargs = {
+            k: params[k] for f in dataclasses.fields(ElevenLabsTTSService.Settings) if (k := f.name) in params
+        }
         return ElevenLabsTTSService(
             api_key=api_key,
             sample_rate=SAMPLE_RATE,
             settings=ElevenLabsTTSService.Settings(
-                model=params["model"],
                 voice=params.get("voice_id", "hpp4J3VqNfWAUOO0d1Us"),
                 language=_base_language(language_code),
+                **elevenlabs_settings_kwargs,
             ),
         )
 

--- a/tests/unit/assistant/test_services.py
+++ b/tests/unit/assistant/test_services.py
@@ -53,6 +53,29 @@ class TestCreateSttService:
         with pytest.raises(ValueError, match="Available:.*deepgram"):
             create_stt_service("nonexistent_provider", params={"api_key": "k"})
 
+    def test_assemblyai_service_created(self):
+        svc = create_stt_service("assemblyai", params={"api_key": "k", "model": "u3-rt-pro"})
+        assert "AssemblyAI" in type(svc).__name__
+        assert svc._settings.model == "u3-rt-pro"
+
+    def test_assemblyai_forwards_optional_settings(self):
+        svc = create_stt_service(
+            "assemblyai",
+            params={
+                "api_key": "k",
+                "model": "u3-rt-pro",
+                "vad_threshold": 0.1,
+                "min_turn_silence": 120,
+            },
+        )
+        assert svc._settings.vad_threshold == 0.1
+        assert svc._settings.min_turn_silence == 120
+
+    def test_assemblyai_ignores_unspecified_settings(self):
+        """Keys absent from params must not be forwarded, so library defaults apply."""
+        svc = create_stt_service("assemblyai", params={"api_key": "k", "model": "u3-rt-pro"})
+        assert svc._settings.vad_threshold is None
+
     def test_nvidia_requires_url(self):
         with pytest.raises(ValueError, match="url required"):
             create_stt_service("nvidia", params={"api_key": "k"})
@@ -66,13 +89,38 @@ class TestCreateSttService:
         assert "Deepgram" in type(svc).__name__
         assert "Flux" not in type(svc).__name__
 
+    def test_deepgram_defaults_interim_results_true(self):
+        svc = create_stt_service("deepgram", params={"api_key": "k", "model": "nova-2"})
+        assert svc._settings.interim_results is True
+
+    def test_deepgram_forwards_optional_settings(self):
+        svc = create_stt_service(
+            "deepgram",
+            params={"api_key": "k", "model": "nova-2", "diarize": True, "interim_results": False},
+        )
+        assert svc._settings.diarize is True
+        assert svc._settings.interim_results is False  # Explicit override wins over the EVA default
+
     def test_deepgram_flux_returns_flux_variant(self):
         svc = create_stt_service("deepgram-flux", params={"api_key": "k", "model": "nova-3"})
         assert "Flux" in type(svc).__name__
 
+    def test_elevenlabs_forwards_vad_settings(self):
+        svc = create_stt_service(
+            "elevenlabs",
+            params={"api_key": "k", "model": "scribe_v1", "vad_threshold": 0.2},
+        )
+        assert svc._settings.vad_threshold == 0.2
+
     def test_openai_service_respects_custom_model(self):
         svc = create_stt_service("openai", params={"api_key": "k", "model": "whisper-2"})
         assert svc._settings.model == "whisper-2"
+
+    def test_xai_stt_defaults_and_forwards(self):
+        svc = create_stt_service("xai", params={"api_key": "k", "model": "grok", "diarize": True, "endpointing": 42})
+        assert svc._settings.diarize is True
+        assert svc._settings.endpointing == 42  # Explicit override wins over the Eva default
+        assert svc._settings.interim_results is True  # EVA default preserved
 
     def test_cartesia_service_created(self):
         svc = create_stt_service("cartesia", params={"api_key": "k", "model": "ink"})
@@ -106,9 +154,26 @@ class TestCreateTtsService:
         svc = create_tts_service("cartesia", params={"api_key": "k", "model": "sonic"})
         assert "Cartesia" in type(svc).__name__
 
+    def test_cartesia_forwards_optional_settings_and_voice_id(self):
+        svc = create_tts_service(
+            "cartesia",
+            params={"api_key": "k", "model": "sonic", "voice_id": "my-voice", "pronunciation_dict_id": "dict-1"},
+        )
+        assert svc._settings.voice == "my-voice"  # Mapped from EVA's voice_id key
+        assert svc._settings.pronunciation_dict_id == "dict-1"
+
     def test_elevenlabs_returns_elevenlabs_service(self):
         svc = create_tts_service("elevenlabs", params={"api_key": "k", "model": "eleven_turbo_v2"})
         assert "ElevenLabs" in type(svc).__name__
+
+    def test_elevenlabs_forwards_voice_tuning(self):
+        svc = create_tts_service(
+            "elevenlabs",
+            params={"api_key": "k", "model": "eleven_turbo_v2", "voice_id": "v1", "stability": 0.7, "speed": 1.1},
+        )
+        assert svc._settings.voice == "v1"  # Mapped from EVA's voice_id key
+        assert svc._settings.stability == 0.7
+        assert svc._settings.speed == 1.1
 
     def test_openai_respects_voice_param(self):
         svc = create_tts_service("openai", params={"api_key": "k", "model": "tts-1", "voice": "nova"})


### PR DESCRIPTION
For example:
```sh
EVA_MODEL__STT_PARAMS='{"api_key": "***", "model": "u3-rt-pro", "vad_threshold": 0.1}'
```