### PR TITLE
reclassify failures on judge errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for smaller final image
 
 # ============================================
-# Stage 1: Deps — only rebuilds when uv.lock changes
+# Stage 1: Deps — only rebuilds when pyproject.toml or uv.lock changes
 # ============================================
 FROM python:3.11-slim AS deps
 
@@ -43,16 +43,6 @@ RUN uv pip install --python /opt/venv/bin/python --no-cache --no-deps .
 # ============================================
 FROM python:3.11-slim AS runtime
 
-# Git provenance baked in at build time
-ARG GIT_COMMIT_SHA
-ARG GIT_BRANCH
-ARG GIT_DIRTY
-ARG GIT_DIFF_HASH
-ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
-ENV GIT_BRANCH=${GIT_BRANCH}
-ENV GIT_DIRTY=${GIT_DIRTY}
-ENV GIT_DIFF_HASH=${GIT_DIFF_HASH}
-
 WORKDIR /app
 
 # Install runtime dependencies (ffmpeg, libsndfile1 for audio; curl for debugging)
@@ -92,6 +82,18 @@ ENV PYTHONUNBUFFERED=1
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import eva; print('ok')" || exit 1
+
+# Git provenance baked in at build time — placed LAST so that changing commit
+# state only invalidates this tiny metadata layer, not the expensive deps/copy
+# layers above it.
+ARG GIT_COMMIT_SHA
+ARG GIT_BRANCH
+ARG GIT_DIRTY
+ARG GIT_DIFF_HASH
+ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV GIT_DIRTY=${GIT_DIRTY}
+ENV GIT_DIFF_HASH=${GIT_DIFF_HASH}
 
 # Switch to non-root user
 USER eva

--- a/src/eva/metrics/runner.py
+++ b/src/eva/metrics/runner.py
@@ -377,8 +377,7 @@ class MetricsRunner:
             metrics_to_compute = {
                 name
                 for name in self.record_metric_filter[record_id]
-                if name in requested_names
-                and (name not in existing_metrics or existing_metrics[name].failed)
+                if name in requested_names and (name not in existing_metrics or existing_metrics[name].failed)
             }
         else:
             # Normal mode: compute all requested if force_rerun, otherwise only missing

--- a/src/eva/metrics/runner.py
+++ b/src/eva/metrics/runner.py
@@ -375,11 +375,17 @@ class MetricsRunner:
         requested_names = {m.name for m in self.metrics}
         if self._is_rerun_mode:
             # Rerun mode: only recompute filter metrics that haven't already succeeded.
+            # A metric "succeeded" only if it is present with no error AND a non-None
+            # score — a None score is just another way a failed computation shows up.
             metrics_to_compute = {
                 name
                 for name in self.record_metric_filter[record_id]
                 if name in requested_names
-                and (name not in existing_metrics or existing_metrics[name].error is not None)
+                and (
+                    name not in existing_metrics
+                    or existing_metrics[name].error is not None
+                    or existing_metrics[name].score is None
+                )
             }
         else:
             # Normal mode: compute all requested if force_rerun, otherwise only missing
@@ -974,12 +980,14 @@ class MetricsRunner:
         )
 
         # Compute metric failures for MetricsRunResult (only for metrics just run)
+        # A metric counts as failed if it errored OR produced a None score — both are
+        # ways a computation can fail to yield a usable value.
         metric_failures: dict[str, list[str]] = {}
         for name in run_metric_names:
             for record_id, record_metrics in all_metrics.items():
                 if name in record_metrics.metrics:
                     score = record_metrics.metrics[name]
-                    if score.error is not None:
+                    if score.error is not None or score.score is None:
                         metric_failures.setdefault(name, []).append(record_id)
 
         # Compute EVA composite run-level aggregates

--- a/src/eva/metrics/runner.py
+++ b/src/eva/metrics/runner.py
@@ -374,18 +374,11 @@ class MetricsRunner:
         # Determine which metrics actually need computation
         requested_names = {m.name for m in self.metrics}
         if self._is_rerun_mode:
-            # Rerun mode: only recompute filter metrics that haven't already succeeded.
-            # A metric "succeeded" only if it is present with no error AND a non-None
-            # score — a None score is just another way a failed computation shows up.
             metrics_to_compute = {
                 name
                 for name in self.record_metric_filter[record_id]
                 if name in requested_names
-                and (
-                    name not in existing_metrics
-                    or existing_metrics[name].error is not None
-                    or existing_metrics[name].score is None
-                )
+                and (name not in existing_metrics or existing_metrics[name].failed)
             }
         else:
             # Normal mode: compute all requested if force_rerun, otherwise only missing
@@ -979,15 +972,12 @@ class MetricsRunner:
             seed=seed,
         )
 
-        # Compute metric failures for MetricsRunResult (only for metrics just run)
-        # A metric counts as failed if it errored OR produced a None score — both are
-        # ways a computation can fail to yield a usable value.
         metric_failures: dict[str, list[str]] = {}
         for name in run_metric_names:
             for record_id, record_metrics in all_metrics.items():
                 if name in record_metrics.metrics:
                     score = record_metrics.metrics[name]
-                    if score.error is not None or score.score is None:
+                    if score.failed:
                         metric_failures.setdefault(name, []).append(record_id)
 
         # Compute EVA composite run-level aggregates

--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -515,6 +515,13 @@ class RunConfig(BaseSettings):
         False,
         description="Force rerun all requested metrics, overwriting existing successful results (requires --run-id)",
     )
+    reclassify_run: bool = Field(
+        False,
+        description="Reclassify previously-failed trial slots by re-validating archived failed attempts "
+        "(reusing their existing simulation) and promoting any that now pass. Only re-validates the "
+        "minimum needed to fill each failed slot; never re-runs simulations. Requires --run-id. "
+        "Respects --record-ids to limit which records are reclassified.",
+    )
     tool_module_path: str | None = Field(
         None,
         description="Python module path with tool functions (e.g., 'eva.assistant.tools.airline_tools'). "

--- a/src/eva/models/results.py
+++ b/src/eva/models/results.py
@@ -116,6 +116,11 @@ class MetricScore(BaseModel):
         None, description="Optional sub-metric breakdowns, aggregated generically by the runner"
     )
 
+    @property
+    def failed(self) -> bool:
+        """True when the metric produced no usable value (errored or None score without being skipped)."""
+        return self.error is not None or (self.score is None and not self.skipped)
+
     @model_validator(mode="after")
     def _auto_stamp_version_and_hash(self) -> "MetricScore":
         # Only fill if unset, so deserialization from disk preserves historical values

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import shutil
 import sys
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TextIO
@@ -1053,7 +1054,7 @@ class BenchmarkRunner:
                 needs_rerun = (
                     not isinstance(entry, dict)
                     or entry.get("error") is not None
-                    or entry.get("score") is None
+                    or (entry.get("score") is None and not entry.get("skipped", False))
                 )
                 if needs_rerun:
                     record_metric_filter.setdefault(record_id, set()).add(name)
@@ -1073,10 +1074,9 @@ class BenchmarkRunner:
         logger.info(
             f"Rerunning {total_reruns} failed metric computation(s) across {len(record_metric_filter)} record(s)"
         )
-        per_metric_counts: dict[str, int] = {}
-        for metrics in record_metric_filter.values():
-            for name in metrics:
-                per_metric_counts[name] = per_metric_counts.get(name, 0) + 1
+        per_metric_counts = Counter(
+            name for metrics in record_metric_filter.values() for name in metrics
+        )
         for name, count in sorted(per_metric_counts.items()):
             logger.info(f"  {name}: {count} record(s)")
 
@@ -1399,7 +1399,6 @@ class BenchmarkRunner:
         with open(eval_summary_path, "w") as f:
             json.dump(eval_summary, f, indent=2, ensure_ascii=False)
 
-        # Audit trail of exactly what moved.
         with open(run_dir / "reclassification_log.json", "w") as f:
             json.dump(reclassification_log, f, indent=2, ensure_ascii=False)
 

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -1074,9 +1074,7 @@ class BenchmarkRunner:
         logger.info(
             f"Rerunning {total_reruns} failed metric computation(s) across {len(record_metric_filter)} record(s)"
         )
-        per_metric_counts = Counter(
-            name for metrics in record_metric_filter.values() for name in metrics
-        )
+        per_metric_counts = Counter(name for metrics in record_metric_filter.values() for name in metrics)
         for name, count in sorted(per_metric_counts.items()):
             logger.info(f"  {name}: {count} record(s)")
 
@@ -1224,9 +1222,7 @@ class BenchmarkRunner:
 
         eval_summary_path = run_dir / "evaluation_summary.json"
         if not eval_summary_path.exists():
-            raise FileNotFoundError(
-                f"evaluation_summary.json not found in {run_dir}. Nothing to reclassify."
-            )
+            raise FileNotFoundError(f"evaluation_summary.json not found in {run_dir}. Nothing to reclassify.")
 
         with open(eval_summary_path) as f:
             eval_summary = json.load(f)
@@ -1362,8 +1358,7 @@ class BenchmarkRunner:
             filled = len(promotions)
             if filled < needed:
                 logger.info(
-                    f"{base}: filled {filled}/{needed} needed trial(s) — "
-                    f"{needed - filled} slot(s) remain failed"
+                    f"{base}: filled {filled}/{needed} needed trial(s) — {needed - filled} slot(s) remain failed"
                 )
             return promotions
 

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -23,6 +23,7 @@ from eva.orchestrator.worker import ConversationWorker
 from eva.utils.conversation_checks import check_conversation_finished, find_records_with_llm_generic_error
 from eva.utils.culture import get_language_addendum
 from eva.utils.logging import get_logger
+from eva.utils.pass_at_k import ATTEMPT_SUFFIX_PATTERN, parse_trial_record_id
 from eva.utils.provenance import capture_provenance, resolve_tool_module_file
 
 logger = get_logger(__name__)
@@ -1020,19 +1021,7 @@ class BenchmarkRunner:
         successful_ids = sim.get("successful_record_ids", [])
 
         metrics_section = eval_summary.get("metrics", {})
-        metric_failures = metrics_section.get("metric_failures", {})
         metrics_computed = metrics_section.get("metrics_computed", [])
-
-        if not metric_failures:
-            logger.info("No metric failures found in evaluation_summary.json — nothing to rerun")
-            ended_at = datetime.now()
-            return RunResult(
-                run_id=self.config.run_id,
-                total_records=len(successful_ids),
-                successful_records=len(successful_ids),
-                failed_records=0,
-                duration_seconds=(ended_at - started_at).total_seconds(),
-            )
 
         # Use explicit CLI --metrics if provided, otherwise prefer metrics_computed
         # from evaluation_summary.json (reflects actual metric names from the last run),
@@ -1043,17 +1032,34 @@ class BenchmarkRunner:
                 "No metrics to run. Specify --metrics or ensure evaluation_summary.json has metrics_computed."
             )
 
-        # Build record_metric_filter: record_id -> set of metric names to rerun
-        successful_set = set(successful_ids)
+        # Build record_metric_filter by scanning each successful record's metrics.json on
+        # disk, rather than trusting the (possibly stale) metric_failures snapshot from
+        # the original run. A metric needs rerunning if it is missing, errored, OR has a
+        # None score — all three mean it never produced a usable value. Scanning disk also
+        # picks up records newly added by reclassification, which the old snapshot missed.
+        records_dir = run_dir / "records"
+        metric_names_set = set(metric_names)
         record_metric_filter: dict[str, set[str]] = {}
-        for metric_name, failed_record_ids in metric_failures.items():
-            if metric_name in metric_names:
-                for record_id in failed_record_ids:
-                    if record_id in successful_set:
-                        record_metric_filter.setdefault(record_id, set()).add(metric_name)
+        for record_id in successful_ids:
+            metrics_path = records_dir / record_id / "metrics.json"
+            existing: dict[str, Any] = {}
+            if metrics_path.exists():
+                try:
+                    existing = json.loads(metrics_path.read_text()).get("metrics", {})
+                except Exception as e:
+                    logger.warning(f"Could not read {metrics_path}: {e}")
+            for name in metric_names_set:
+                entry = existing.get(name)
+                needs_rerun = (
+                    not isinstance(entry, dict)
+                    or entry.get("error") is not None
+                    or entry.get("score") is None
+                )
+                if needs_rerun:
+                    record_metric_filter.setdefault(record_id, set()).add(name)
 
         if not record_metric_filter:
-            logger.info("No applicable metric failures to rerun")
+            logger.info("No missing/failed/none-score metrics to rerun")
             ended_at = datetime.now()
             return RunResult(
                 run_id=self.config.run_id,
@@ -1067,11 +1073,12 @@ class BenchmarkRunner:
         logger.info(
             f"Rerunning {total_reruns} failed metric computation(s) across {len(record_metric_filter)} record(s)"
         )
-        for metric_name, failed_ids in metric_failures.items():
-            if metric_name in metric_names:
-                applicable = [rid for rid in failed_ids if rid in record_metric_filter]
-                if applicable:
-                    logger.info(f"  {metric_name}: {len(applicable)} record(s)")
+        per_metric_counts: dict[str, int] = {}
+        for metrics in record_metric_filter.values():
+            for name in metrics:
+                per_metric_counts[name] = per_metric_counts.get(name, 0) + 1
+        for name, count in sorted(per_metric_counts.items()):
+            logger.info(f"  {name}: {count} record(s)")
 
         # Create MetricsRunner with all metrics but filter per-record.
         # Records not in record_metric_filter will read existing metrics from disk.
@@ -1120,6 +1127,321 @@ class BenchmarkRunner:
             total_records=len(successful_ids),
             successful_records=len(successful_ids),
             failed_records=0,
+            duration_seconds=(ended_at - started_at).total_seconds(),
+        )
+
+    @staticmethod
+    def _errored_validation_metrics(record_dir: Path) -> list[str]:
+        """Return validation metrics whose stored value carries an ``error``.
+
+        A non-empty result means the prior judging "did not go smoothly" (e.g. the
+        judge hit a transient/config error), which is what makes an archived attempt a
+        promotion candidate. An attempt whose validation metrics were all cleanly scored
+        — a genuine failure — returns an empty list and is not a candidate.
+        """
+        metrics_path = record_dir / "metrics.json"
+        if not metrics_path.exists():
+            return []
+        try:
+            metrics = json.loads(metrics_path.read_text()).get("metrics", {})
+        except Exception as e:
+            logger.warning(f"Could not read {metrics_path} to inspect errored metrics: {e}")
+            return []
+        return [
+            name
+            for name in ValidationRunner.VALIDATION_METRICS
+            if isinstance(metrics.get(name), dict) and metrics[name].get("error") is not None
+        ]
+
+    @staticmethod
+    def _clear_metrics(record_dir: Path, names: list[str]) -> None:
+        """Drop the named metric entries from a record's metrics.json.
+
+        Removed metrics are treated as "missing" by MetricsRunner, forcing a fresh
+        re-judge on the next validation pass. Genuine (non-errored) scores are left in
+        place so they are reused rather than recomputed.
+        """
+        metrics_path = record_dir / "metrics.json"
+        if not metrics_path.exists() or not names:
+            return
+        try:
+            data = json.loads(metrics_path.read_text())
+        except Exception as e:
+            logger.warning(f"Could not read {metrics_path} to clear metrics: {e}")
+            return
+        metrics = data.get("metrics", {})
+        removed = [n for n in names if n in metrics]
+        if not removed:
+            return
+        for n in removed:
+            del metrics[n]
+        metrics_path.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+        logger.info(f"{record_dir.name}: cleared errored validation metrics for re-judge: {removed}")
+
+    async def reclassify_run(
+        self,
+        run_dir: Path,
+        records: list[EvaluationRecord],
+        cli_metrics: list[str] | None = None,
+    ) -> RunResult:
+        """Reclassify failed records by re-judging archived attempts that erred.
+
+        Goal: bring each record up to ``num_trials`` successful trials by reusing its own
+        already-run simulations. A record that is short of ``num_trials`` draws on the
+        pool of *all* its archived failed attempts (across every trial index), not just
+        the attempts tied to one slot.
+
+        Candidate rule — the key to not being wasteful and to never "forcing" a pass: an
+        archived attempt is a promotion candidate only if its prior judging *did not go
+        smoothly*, i.e. a validation metric was stored with an ``error`` (e.g. the judge
+        hit a bad API key). Attempts that were cleanly scored as genuine failures are
+        left alone. For a candidate, only the errored validation metrics are re-judged;
+        cleanly-scored ones are reused.
+
+        Per record, candidates are re-judged serially and the record stops as soon as it
+        reaches ``num_trials`` — so a record may inspect many attempts, but never more
+        than it needs. Different records are processed concurrently, bounded by the run's
+        concurrency limit; the LiteLLM Router further bounds judge API calls.
+
+        Each passing candidate is promoted (moved) into a free ``trial_{N}`` slot. Then
+        evaluation_summary.json and results.csv are reconciled, the full metric suite is
+        computed on promoted slots (reusing existing metrics), and every promotion is
+        recorded in reclassification_log.json.
+
+        Args:
+            run_dir: Path to existing run directory.
+            records: Full list of evaluation records.
+            cli_metrics: Metrics to compute on promoted records (defaults to config).
+
+        Returns:
+            RunResult with post-reclassification counts and duration.
+        """
+        logger.info(f"Reclassifying failed records in {run_dir}")
+        started_at = datetime.now()
+        self.output_dir = run_dir
+        records_dir = run_dir / "records"
+        num_trials = self.config.num_trials
+
+        eval_summary_path = run_dir / "evaluation_summary.json"
+        if not eval_summary_path.exists():
+            raise FileNotFoundError(
+                f"evaluation_summary.json not found in {run_dir}. Nothing to reclassify."
+            )
+
+        with open(eval_summary_path) as f:
+            eval_summary = json.load(f)
+
+        sim = eval_summary.get("simulation", eval_summary)
+        failed_ids: list[str] = list(sim.get("failed_record_ids", []))
+        successful_ids: list[str] = list(sim.get("successful_record_ids", []))
+
+        def _no_op_result() -> RunResult:
+            ended = datetime.now()
+            return RunResult(
+                run_id=self.config.run_id,
+                total_records=len(successful_ids) + len(failed_ids),
+                successful_records=len(successful_ids),
+                failed_records=len(failed_ids),
+                duration_seconds=(ended - started_at).total_seconds(),
+            )
+
+        if not failed_ids:
+            logger.info("No failed records in evaluation_summary.json — nothing to reclassify")
+            return _no_op_result()
+
+        # ── Group by base record; compute how many trials each still needs ──
+        record_id_filter = set(self.config.record_ids) if self.config.record_ids else None
+
+        # Records that appear in failed_ids are the ones potentially short of num_trials.
+        needy_records: set[str] = set()
+        for oid in failed_ids:
+            base, _ = parse_trial_record_id(oid)
+            if record_id_filter is None or base in record_id_filter:
+                needy_records.add(base)
+
+        if not needy_records:
+            logger.info("No failed records match the requested --record-ids — nothing to reclassify")
+            return _no_op_result()
+
+        all_records = list({id(r): r for r in records}.values())
+        validation_runner = ValidationRunner(
+            run_dir=run_dir,
+            dataset=all_records,
+            thresholds=self.config.validation_thresholds,
+            metric_configs=self._metric_configs,
+        )
+
+        # Different records run concurrently; candidates within a record run serially so
+        # we stop the moment num_trials is reached (no wasted judge compute).
+        semaphore = asyncio.Semaphore(self.config.max_concurrent_conversations)
+        successful_set = set(successful_ids)
+
+        def _slot_output_id(base: str, i: int) -> str:
+            return f"{base}/trial_{i}" if num_trials > 1 else base
+
+        def _free_slots(base: str) -> list[int]:
+            """Trial indices NOT yet backed by a *successful* trial.
+
+            A slot is satisfied only if its output id is in the successful set from the
+            summary — NOT merely because a canonical dir exists on disk. A canonical dir
+            can be a leftover from an interrupted prior promotion (moved into place but
+            never recorded); such a slot is still free and its dir is re-judged below.
+            """
+            return [i for i in range(num_trials) if _slot_output_id(base, i) not in successful_set]
+
+        def _candidate_pool(base: str, free: list[int]) -> list[Path]:
+            """Re-judge candidates for a record, newest attempt first.
+
+            Includes archived ``_failed_attempt_`` dirs AND any leftover/failed canonical
+            ``trial_{i}`` dir for a free slot (from an interrupted prior run).
+            """
+            base_dir = records_dir / base
+            if num_trials > 1:
+                archived = base_dir.glob("trial_*_failed_attempt_*") if base_dir.exists() else []
+            else:
+                archived = records_dir.glob(f"{base}_failed_attempt_*")
+            cands = [d for d in archived if d.is_dir() and ATTEMPT_SUFFIX_PATTERN.search(d.name)]
+            cands.sort(key=lambda d: int(ATTEMPT_SUFFIX_PATTERN.search(d.name).group(2)), reverse=True)
+            # Prepend leftover canonical dirs for free slots so an already-in-place
+            # attempt is tried first (and, if it passes, needs no move).
+            leftovers = [
+                records_dir / _slot_output_id(base, i)
+                for i in free
+                if (records_dir / _slot_output_id(base, i)).exists()
+            ]
+            return leftovers + cands
+
+        async def _reclassify_record(base: str) -> list[dict]:
+            free = _free_slots(base)
+            if not free:
+                logger.info(f"{base}: already has {num_trials} successful trial(s) — skipping")
+                return []
+            needed = len(free)
+            candidates = _candidate_pool(base, free)
+            if not candidates:
+                logger.info(f"{base}: no attempts to re-judge — leaving failed")
+                return []
+
+            promotions: list[dict] = []
+            async with semaphore:
+                for cand in candidates:
+                    if not free:
+                        break
+                    # Candidate rule: only attempts whose prior judging erred. Cleanly
+                    # scored genuine failures are skipped — never re-judged or forced.
+                    errored = self._errored_validation_metrics(cand)
+                    if not errored:
+                        continue
+                    self._clear_metrics(cand, errored)
+                    cand_output_id = str(cand.relative_to(records_dir))
+                    vr = await validation_runner.validate_one(cand_output_id)
+                    if not vr.passed:
+                        logger.info(f"{base}: re-judged '{cand.name}' still fails validation")
+                        continue
+
+                    slot_idx = free.pop(0)
+                    target = records_dir / _slot_output_id(base, slot_idx)
+                    if cand.resolve() != target.resolve():
+                        # A leftover/failed canonical dir may be occupying the target slot;
+                        # archive it aside before moving the winning candidate into place.
+                        if target.exists():
+                            self._archive_failed_attempt(_slot_output_id(base, slot_idx), 1)
+                        shutil.move(str(cand), str(target))
+                    logger.info(
+                        f"{base}: promoted '{cand.name}' into 'trial_{slot_idx}' — now passes "
+                        f"validation (scores={vr.scores})"
+                    )
+                    promotions.append(
+                        {
+                            "output_id": _slot_output_id(base, slot_idx),
+                            "record_id": base,
+                            "promoted_from": cand.name,
+                            "reclassified_at": started_at.isoformat(),
+                        }
+                    )
+            filled = len(promotions)
+            if filled < needed:
+                logger.info(
+                    f"{base}: filled {filled}/{needed} needed trial(s) — "
+                    f"{needed - filled} slot(s) remain failed"
+                )
+            return promotions
+
+        record_results = await asyncio.gather(*(_reclassify_record(b) for b in sorted(needy_records)))
+        reclassification_log = [p for record_promos in record_results for p in record_promos]
+        promoted = [p["output_id"] for p in reclassification_log]
+
+        if not promoted:
+            logger.info("No candidate attempts passed re-judging — nothing promoted")
+            return _no_op_result()
+
+        # ── Reconcile evaluation_summary.json ──
+        promoted_set = set(promoted)
+        new_successful = sorted(set(successful_ids) | promoted_set)
+        new_failed = sorted(set(sim.get("failed_record_ids", [])) - promoted_set)
+        total = len(new_successful) + len(new_failed)
+
+        sim["successful_record_ids"] = new_successful
+        sim["failed_record_ids"] = new_failed
+        sim["successful_records"] = len(new_successful)
+        sim["failed_records"] = len(new_failed)
+        sim["success_rate"] = len(new_successful) / total if total > 0 else 0.0
+        sim["failure_rate"] = len(new_failed) / total if total > 0 else 0.0
+
+        final_failures = eval_summary.get("final_failures", {})
+        for oid in promoted_set:
+            final_failures.pop(oid, None)
+        eval_summary["final_failures"] = final_failures
+        eval_summary["reclassification_history"] = (
+            eval_summary.get("reclassification_history", []) + reclassification_log
+        )
+
+        with open(eval_summary_path, "w") as f:
+            json.dump(eval_summary, f, indent=2, ensure_ascii=False)
+
+        # Audit trail of exactly what moved.
+        with open(run_dir / "reclassification_log.json", "w") as f:
+            json.dump(reclassification_log, f, indent=2, ensure_ascii=False)
+
+        # ── Rebuild results.csv from the reconciled successful set ──
+        successful_results: list[tuple[str, ConversationResult]] = []
+        for output_id in new_successful:
+            result_path = records_dir / output_id / "result.json"
+            if result_path.exists():
+                with open(result_path) as rf:
+                    successful_results.append((output_id, ConversationResult(**json.load(rf))))
+        self._save_results_csv(successful_results, new_failed)
+
+        logger.info(f"Promoted {len(promoted)} slot(s): {', '.join(promoted)}")
+
+        # ── Compute full metrics on promoted slots (reuses existing validation metrics) ──
+        metric_names = cli_metrics or self.config.metrics
+        if metric_names:
+            logger.info(f"Computing metrics on {len(promoted)} promoted slot(s)...")
+            metrics_runner = MetricsRunner(
+                run_dir=run_dir,
+                dataset=records,
+                metric_names=metric_names,
+                metric_configs=self._metric_configs,
+                record_ids=promoted,
+                num_draws=self.config.num_trials,
+            )
+            await metrics_runner.run()
+        else:
+            logger.info("No metrics configured — skipping metric computation on promoted slots")
+
+        logger.info("=" * 60)
+        logger.info("RECLASSIFICATION COMPLETE")
+        logger.info(f"  Promoted: {len(promoted)}")
+        logger.info(f"  Remaining failed: {len(new_failed)}")
+        logger.info("=" * 60)
+
+        ended_at = datetime.now()
+        return RunResult(
+            run_id=self.config.run_id,
+            total_records=total,
+            successful_records=len(new_successful),
+            failed_records=len(new_failed),
             duration_seconds=(ended_at - started_at).total_seconds(),
         )
 

--- a/src/eva/run_benchmark.py
+++ b/src/eva/run_benchmark.py
@@ -63,6 +63,18 @@ async def run_benchmark(config: RunConfig) -> int:
             logger.error(f"Failed to load dataset: {e}")
             return 1
 
+        if config.reclassify_run:
+            # ── Reclassify failed trial slots from reusable archived attempts ──
+            try:
+                await runner.reclassify_run(resolved_dir, records, cli_metrics=config.metrics)
+                return 0
+            except KeyboardInterrupt:
+                logger.warning("Reclassification interrupted by user")
+                return 130
+            except Exception as e:
+                logger.error(f"Reclassification failed: {e}", exc_info=True)
+                return 1
+
         if config.rerun_failed_metrics:
             # ── Rerun only previously failed metric computations ──
             try:
@@ -90,6 +102,10 @@ async def run_benchmark(config: RunConfig) -> int:
 
     if config.rerun_failed_metrics:
         logger.error("--rerun-failed-metrics requires --run-id pointing to an existing run")
+        return 1
+
+    if config.reclassify_run:
+        logger.error("--reclassify-run requires --run-id pointing to an existing run")
         return 1
 
     # Load dataset


### PR DESCRIPTION
Add argument to reclassify runs if there was an error computing the judge metric that led to it being marked as failed. This does not waste money on reruns if the run is already a clean "this one failed", only if for example, a judge api key was missing and the record "fails" but you don't actually need to redo the simulation, you can just attempt to reclassify.

A difference between this and rerun-failed-metrics is that this actually promotes the record after re-rating 

I also move the git provenance in the docker file because it reduces the push size from 1.5gb to 50 mb or so. much better development speed this way