### PR TITLE
Add token usage metrics to turn_taking

### DIFF
--- a/src/eva/metrics/diagnostic/response_speed.py
+++ b/src/eva/metrics/diagnostic/response_speed.py
@@ -129,13 +129,23 @@ class ResponseSpeedMetric(CodeMetric):
                         details=stats,
                     )
 
-            # Add per-component latency sub_metrics from result.json
+            # Add per-component latency sub_metrics from result.json.
+            # result.json stores these in milliseconds; convert to seconds here
+            # to match the top-level response_speed score (already in seconds).
             for key, latency_stats in _load_component_latencies(context.output_dir).items():
+                seconds_details = {
+                    (f"{stat_key[:-3]}_seconds" if stat_key.endswith("_ms") else stat_key): (
+                        round(stat_value / 1000, 3)
+                        if stat_key.endswith("_ms") and stat_value is not None
+                        else stat_value
+                    )
+                    for stat_key, stat_value in latency_stats.items()
+                }
                 sub_metrics[key] = MetricScore(
                     name=f"{self.name}.{key}",
-                    score=latency_stats["mean_ms"],
+                    score=round(latency_stats["mean_ms"] / 1000, 3),
                     normalized_score=None,
-                    details=latency_stats,
+                    details=seconds_details,
                 )
 
             return MetricScore(

--- a/src/eva/metrics/experience/turn_taking.py
+++ b/src/eva/metrics/experience/turn_taking.py
@@ -47,6 +47,7 @@ from typing import Any
 from eva.metrics.base import CodeMetric, MetricContext
 from eva.metrics.processor import is_agent_timeout_on_user_turn
 from eva.metrics.registry import register_metric
+from eva.metrics.utils import mean_agent_perf_stat
 from eva.models.results import MetricScore
 
 
@@ -428,6 +429,14 @@ class TurnTakingMetric(CodeMetric):
             sub["user_interruption.mean_yield_score"] = _wrap(
                 "user_interruption.mean_yield_score", round(statistics.mean(yield_scores), 4), True
             )
+
+        # Token usage (from agent_perf_stats.csv)
+        mean_output_tokens = mean_agent_perf_stat(context.output_dir, "output_tokens")
+        mean_reasoning_tokens = mean_agent_perf_stat(context.output_dir, "reasoning_tokens")
+        if mean_output_tokens is not None:
+            sub["mean_output_tokens"] = _wrap("mean_output_tokens", round(mean_output_tokens, 3), False)
+        if mean_reasoning_tokens is not None:
+            sub["mean_reasoning_tokens"] = _wrap("mean_reasoning_tokens", round(mean_reasoning_tokens, 3), False)
 
         return sub
 

--- a/src/eva/metrics/utils.py
+++ b/src/eva/metrics/utils.py
@@ -1,10 +1,11 @@
 """Shared utilities for metrics computation."""
 
 import base64
+import csv
 from io import BytesIO
 from itertools import groupby
 from pathlib import Path
-from statistics import harmonic_mean
+from statistics import harmonic_mean, mean
 from typing import Any
 
 from pydub import AudioSegment
@@ -504,3 +505,38 @@ def aggregate_per_turn_scores(scores: list[float | None], aggregation: str) -> f
         Aggregated score or None if all scores are None
     """
     return compute_aggregation(aggregation, scores)
+
+
+def mean_agent_perf_stat(
+    output_dir: str | Path,
+    column: str,
+) -> float | None:
+    """Mean of one numeric column across the LLM calls in ``agent_perf_stats.csv``.
+
+    Reads the per-LLM-call CSV (written by the agentic system) from the record's
+    ``output_dir`` and averages the values in ``column`` over the rows. Returns
+    ``None`` when the CSV is missing/empty or the column has no numeric values.
+    """
+    csv_path = Path(output_dir) / "agent_perf_stats.csv"
+    if not csv_path.exists():
+        return None, None
+
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+    except OSError:
+        return None, None
+
+    if not rows:
+        return None, None
+
+    values: list[float] = []
+    for row in rows:
+        raw = (row.get(column) or "").strip()
+        if not raw:
+            continue
+        try:
+            values.append(float(raw))
+        except ValueError:
+            continue
+    return mean(values) if values else None

--- a/src/eva/metrics/utils.py
+++ b/src/eva/metrics/utils.py
@@ -519,16 +519,16 @@ def mean_agent_perf_stat(
     """
     csv_path = Path(output_dir) / "agent_perf_stats.csv"
     if not csv_path.exists():
-        return None, None
+        return None
 
     try:
         with open(csv_path, newline="", encoding="utf-8") as f:
             rows = list(csv.DictReader(f))
     except OSError:
-        return None, None
+        return None
 
     if not rows:
-        return None, None
+        return None
 
     values: list[float] = []
     for row in rows:

--- a/tests/fixtures/metric_signatures.json
+++ b/tests/fixtures/metric_signatures.json
@@ -44,7 +44,7 @@
   "ResponseSpeedMetric": {
     "name": "response_speed",
     "prompt_hash": null,
-    "source_hash": "7cd7e8baa3d2",
+    "source_hash": "fdac735ba008",
     "version": "v0.2"
   },
   "STTWERMetric": {

--- a/tests/fixtures/metric_signatures.json
+++ b/tests/fixtures/metric_signatures.json
@@ -92,7 +92,7 @@
   "TurnTakingMetric": {
     "name": "turn_taking",
     "prompt_hash": null,
-    "source_hash": "0ae7b7f0fc8c",
+    "source_hash": "fee8caa7adc7",
     "version": "v0.1"
   },
   "UserBehavioralFidelityMetric": {


### PR DESCRIPTION
- add mean output_tokens and mean response_tokens from agent_perf_stats to the turn_taking metric
- convert response_speed llm/tts/stt latency scores to seconds to match response_speed score