### PR TITLE
Refactor/user sim phase0

### DIFF
--- a/src/eva/backend/__init__.py
+++ b/src/eva/backend/__init__.py
@@ -1,0 +1,22 @@
+"""Provider-agnostic ``Backend`` abstraction (design-only, Step 1 of the refactor).
+
+This package defines the contracts described in ``docs/refactor-step1.md``:
+pure API/session objects (``Backend``) that know nothing about role
+(assistant vs. user), plus a factory to construct them. Nothing in this
+package is wired into the existing ``eva.assistant`` / ``eva.user_simulator``
+code yet -- these are new, additive, currently-unused types.
+"""
+
+from eva.backend.base import Backend, BackendEvent, BackendEventType, ToolCallRequest, ToolCallResult
+from eva.backend.capabilities import BackendCapabilities
+from eva.backend.factory import BackendFactory
+
+__all__ = [
+    "Backend",
+    "BackendCapabilities",
+    "BackendEvent",
+    "BackendEventType",
+    "BackendFactory",
+    "ToolCallRequest",
+    "ToolCallResult",
+]

--- a/src/eva/backend/base.py
+++ b/src/eva/backend/base.py
@@ -1,0 +1,272 @@
+"""Abstract ``Backend`` contract: pure API/session exchange, no role knowledge.
+
+DESIGN ONLY (Step 1 of the refactor, see docs/refactor-step1.md). This module
+defines shapes, not behavior -- every method body is a stub. Nothing in
+``eva.assistant`` or ``eva.user_simulator`` depends on this yet.
+
+A ``Backend`` wraps exactly one provider integration (OpenAI Realtime, Gemini
+Live, ElevenLabs Agents, a cascade STT->LLM->TTS pipeline, ...) and exposes a
+uniform send/receive surface for exchanging audio, text, and tool-call
+traffic with that provider. It has **no opinion about role** -- it does not
+know whether it is being driven by an ``AssistantRole`` or a ``UserRole``,
+and it does not decide *what* prompt or tools to use (the ``Role`` supplies
+those at open-time and owns tool execution).
+
+Symmetry note (per the design doc): a ``Backend`` must not assume it is "the
+network server side" or "the client side" of a connection. Today,
+assistant-side backends happen to be reached by an inbound WebSocket
+connection (Twilio-framed) and user-side backends happen to dial out to a
+provider or to the assistant's socket. Both are just implementation details
+of a concrete subclass's ``open()``/``send()``/``receive()`` -- the abstract
+contract itself is direction-agnostic so that a later mediator can sit
+between two ``Backend`` instances (Backend <-> mediator <-> Backend) without
+requiring either side to be "the server."
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from eva.backend.capabilities import BackendCapabilities
+
+
+class BackendEventType(str, Enum):
+    """Kinds of events a ``Backend`` can surface via ``receive()``.
+
+    Not every ``Backend`` implementation will emit every event type -- a thin,
+    end-to-end backend (e.g. ElevenLabs Agents) may only ever emit
+    ``AUDIO_OUTPUT``, ``TRANSCRIPT``, ``TURN_END``, and ``ERROR``, because it
+    has no separable tool-calling seam of its own that the caller can observe
+    (tool calls, if any, happen inside the provider and are not surfaced).
+    Consumers must treat unhandled event types as ignorable, not as errors.
+    """
+
+    AUDIO_OUTPUT = "audio_output"
+    """A chunk of output audio from the backend (assistant speech, or the
+    simulated user's speech, depending on which role's Backend this is)."""
+
+    TRANSCRIPT = "transcript"
+    """A (possibly partial) transcript of something spoken -- either the
+    backend's own output or, for backends that provide it, the other party's
+    input as heard by this backend's ASR."""
+
+    TOOL_CALL_REQUEST = "tool_call_request"
+    """The backend's model wants to invoke a tool. Only emitted by backends
+    that expose a separable tool-calling seam (native S2S realtime APIs,
+    cascade LLM backends). The owning ``Role`` is responsible for executing
+    the tool and returning the result via ``send(tool_result=...)`` -- the
+    ``Backend`` never executes tools itself (see docs/refactor-step1.md,
+    "tool execution stays role-side")."""
+
+    TURN_END = "turn_end"
+    """The backend's model has finished its current turn (end-of-utterance /
+    end-of-response signal)."""
+
+    ERROR = "error"
+    """A provider-level error occurred (connection drop, API error, etc.)."""
+
+
+@dataclass
+class ToolCallRequest:
+    """A tool invocation requested by a backend's underlying model.
+
+    Surfaced via a ``BackendEvent`` of type ``TOOL_CALL_REQUEST``. The owning
+    ``Role`` executes the tool (via its own ``ToolExecutor``) and reports the
+    outcome back to the backend with ``Backend.send(tool_result=...)`` so the
+    provider's tool-calling loop can continue.
+    """
+
+    call_id: str
+    """Provider-assigned identifier correlating the request to its result."""
+
+    name: str
+    """Tool name as requested by the model."""
+
+    arguments: dict[str, Any]
+    """Parsed tool call arguments."""
+
+
+@dataclass
+class ToolCallResult:
+    """The outcome of executing a ``ToolCallRequest``, to be sent back to the
+    backend so its underlying model can continue the tool-calling loop."""
+
+    call_id: str
+    """Must match the ``call_id`` of the originating ``ToolCallRequest``."""
+
+    result: Any
+    """JSON-serializable tool result payload."""
+
+
+@dataclass
+class BackendEvent:
+    """A single event surfaced by ``Backend.receive()``.
+
+    Exactly one of the optional payload fields is populated, matching
+    ``event_type``. This is intentionally a loose envelope (rather than a
+    tagged union of dataclasses) so that thin backends can populate only the
+    fields they support without needing empty placeholder subclasses.
+    """
+
+    event_type: BackendEventType
+    audio: bytes | None = None
+    transcript: str | None = None
+    tool_call_request: ToolCallRequest | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    """Provider-specific extras (e.g. raw event name, timestamps) that don't
+    warrant a first-class field. Consumers should not rely on specific keys
+    being present across providers.
+
+    Convention (not enforced by this contract): a backend that proactively
+    re-engages after an idle period (see ``AssistantRole``'s
+    ``self_nudge_timeout_seconds``) may set ``metadata["is_nudge"] = True`` on
+    the ``AUDIO_OUTPUT``/``TRANSCRIPT`` event it emits for that turn, purely
+    so callers that want to distinguish a self-initiated nudge from an
+    ordinary model turn (e.g. for audit logging) can do so. This is *not* a
+    new event type -- a nudge is just an ordinary turn from the backend's
+    model, triggered by the backend noticing its own idle timeout rather than
+    by new input; it flows through the same ``receive()`` surface as
+    anything else."""
+
+
+class Backend(ABC):
+    """Pure API/session exchange with one provider. No role knowledge.
+
+    Lifecycle: ``open()`` establishes the session, ``send()`` pushes audio /
+    text / tool results to the provider, ``receive()`` yields events back,
+    and ``close()`` tears the session down. A ``Role`` (see
+    ``eva.role.base``) owns one ``Backend`` instance and drives it.
+
+    Implementations are expected to fall along a spectrum:
+
+    - **Native speech-to-speech** (OpenAI Realtime, Gemini Live): a single
+      persistent duplex session; ``send(audio=...)`` streams mic audio in,
+      ``receive()`` yields interleaved ``AUDIO_OUTPUT``/``TRANSCRIPT``/
+      ``TOOL_CALL_REQUEST``/``TURN_END`` events as the provider produces them.
+    - **Cascade** (STT -> LLM -> TTS, e.g. a Pipecat pipeline): internally
+      composed of separate provider calls, but from the caller's perspective
+      still just one ``Backend`` -- it decides internally when to run STT,
+      call the LLM, and synthesize TTS, and surfaces the same event shape.
+    - **End-to-end / thin** (ElevenLabs Agents): the provider handles
+      everything (ASR, dialogue policy, TTS) opaquely. Such a ``Backend``
+      may only ever emit ``AUDIO_OUTPUT``/``TRANSCRIPT``/``TURN_END``/
+      ``ERROR`` and may treat ``send(tool_result=...)`` as a no-op or raise
+      ``NotImplementedError`` -- callers must consult ``capabilities`` and
+      not assume every method does something on every backend.
+
+    Symmetry: this contract says nothing about which side dials out and
+    which side is dialed into -- see the module docstring.
+    """
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> BackendCapabilities:
+        """Static capability flags for this backend (see ``BackendCapabilities``).
+
+        Must be available even before ``open()`` is called (i.e. it describes
+        the provider integration, not live session state).
+        """
+        ...
+
+    @abstractmethod
+    async def open(self, *, system_prompt: str, tools: list[dict[str, Any]] | None, config: dict[str, Any]) -> None:
+        """Establish the provider session.
+
+        Args:
+            system_prompt: Fully-built system prompt for this session, as
+                assembled by the owning ``Role`` (``Role.build_prompt()``).
+                A thin end-to-end backend still receives this even if it
+                maps it onto a different provider concept (e.g. ElevenLabs
+                agent overrides).
+            tools: Tool schemas to expose to the provider's model, in
+                whatever wire format the concrete backend needs to translate
+                from the agent's tool definitions. ``None`` or ``[]`` for
+                backends/roles that don't expose tool calling (e.g. a
+                ``UserRole`` that only needs an ``end_call`` tool would still
+                pass that single tool here; a backend with no tool-calling
+                seam at all may simply ignore this argument).
+            config: Provider-specific configuration blob (model name, voice,
+                sample rate, turn-detection parameters, etc.). Deliberately
+                untyped here -- each concrete ``Backend`` defines and
+                validates its own config shape; the abstract contract does
+                not prescribe one, since a native S2S config and a cascade
+                config share little structure. An ``AssistantRole`` backend
+                configured to self-nudge (see
+                ``AssistantRole.self_nudge_timeout_seconds``) reads its
+                threshold from this blob (e.g. a
+                ``config["self_nudge_timeout_seconds"]`` key) the same way --
+                self-nudging needs no dedicated typed parameter or new
+                ``Backend`` method, since the resulting nudge is just an
+                ordinary outbound turn (see ``BackendEvent.metadata``).
+
+        Must be safe to call exactly once per ``Backend`` instance. Must not
+        block on the other party being ready to exchange data -- readiness to
+        *accept* traffic is enough (mirrors today's
+        ``AbstractAssistantServer.start()`` contract: non-blocking, returns
+        once ready).
+        """
+        ...
+
+    @abstractmethod
+    async def send(
+        self,
+        *,
+        audio: bytes | None = None,
+        text: str | None = None,
+        tool_result: ToolCallResult | None = None,
+    ) -> None:
+        """Push data to the provider. Exactly one of the keyword args is set.
+
+        Args:
+            audio: Raw input audio chunk (format/sample-rate is whatever this
+                backend's ``open(config=...)`` declared; format conversion is
+                the caller's responsibility via the shared audio utilities,
+                not this method's).
+            text: A text turn to inject directly (e.g. a starting utterance,
+                or a cascade backend's synthesized user/assistant text before
+                TTS). Backends that are audio-only end-to-end (no text
+                injection seam) may raise ``NotImplementedError``.
+            tool_result: The result of executing a previously-surfaced
+                ``ToolCallRequest``, to be relayed back into the provider's
+                tool-calling loop so it can continue. Backends with no
+                tool-calling seam (see ``capabilities``) may raise
+                ``NotImplementedError``.
+
+        This is intentionally the single, symmetric outbound method for both
+        "network-server-like" and "client-like" backends -- see the module
+        docstring on symmetry. A future mediator sitting between two
+        ``Backend`` instances would call this same method on each side.
+        """
+        ...
+
+    @abstractmethod
+    def receive(self) -> AsyncIterator[BackendEvent]:
+        """Yield events from the provider as they arrive.
+
+        The single, symmetric inbound stream for both "network-server-like"
+        and "client-like" backends. Must be an async generator (or return an
+        object implementing ``__aiter__``/``__anext__``) that yields until
+        the session ends (``close()`` is called, the provider disconnects,
+        or a terminal ``ERROR``/``TURN_END``-with-hangup event occurs --
+        exact termination semantics are provider-specific and left to each
+        concrete backend).
+        """
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Tear down the provider session.
+
+        Must be safe to call even if ``open()`` was never called or the
+        session already ended on its own (idempotent). Concrete backends are
+        responsible for their own provider-specific teardown (closing
+        websockets, cancelling tasks, flushing buffers); this method does not
+        itself define audio/output persistence -- that remains a ``Role``
+        concern (see ``eva.role.base``).
+        """
+        ...

--- a/src/eva/backend/base.py
+++ b/src/eva/backend/base.py
@@ -28,13 +28,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from eva.backend.capabilities import BackendCapabilities
 
 
-class BackendEventType(str, Enum):
+class BackendEventType(StrEnum):
     """Kinds of events a ``Backend`` can surface via ``receive()``.
 
     Not every ``Backend`` implementation will emit every event type -- a thin,
@@ -92,8 +92,11 @@ class ToolCallRequest:
 
 @dataclass
 class ToolCallResult:
-    """The outcome of executing a ``ToolCallRequest``, to be sent back to the
-    backend so its underlying model can continue the tool-calling loop."""
+    """The outcome of executing a ``ToolCallRequest``.
+
+    To be sent back to the backend so its underlying model can continue the
+    tool-calling loop.
+    """
 
     call_id: str
     """Must match the ``call_id`` of the originating ``ToolCallRequest``."""

--- a/src/eva/backend/capabilities.py
+++ b/src/eva/backend/capabilities.py
@@ -1,0 +1,48 @@
+"""Capability flags describing what a ``Backend`` implementation can do.
+
+These flags exist so that a future mediator/turn-taking layer can branch on
+backend shape without every ``Backend`` implementation needing to expose the
+same granular seams. Per docs/refactor-step1.md, they are declared now but
+must remain UNUSED in this step -- no turn-taking logic should read them yet.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BackendCapabilities:
+    """Static, provider-declared capability flags for a ``Backend``.
+
+    Each concrete ``Backend`` subclass sets these once (typically as a class
+    attribute or constructed in ``__init__``) to describe its streaming shape.
+    They are informational only in this step -- nothing consumes them yet.
+
+    Attributes:
+        emits_continuous_audio: True if the backend produces a continuous
+            audio stream once speaking starts (native speech-to-speech models
+            such as OpenAI Realtime or Gemini Live, and end-to-end providers
+            such as ElevenLabs Agents). False for cascade backends
+            (STT -> LLM -> TTS) that emit discrete, chunked utterances with
+            gaps between TTS renders. This is the flag a future mediator uses
+            to decide whether "audio is still arriving" is a meaningful
+            signal on its own, or whether it must also track discrete
+            utterance boundaries.
+        supports_streaming_interruption: True if the underlying provider API
+            supports being told "stop talking now" mid-utterance and reacting
+            immediately (e.g. OpenAI/Gemini Realtime `response.cancel`-style
+            semantics). False if interruption can only be approximated by the
+            caller (e.g. stop forwarding audio, drop the rest of a queued TTS
+            buffer) rather than being a first-class provider feature. Declared
+            for later interruption-policy work; not consumed in this step.
+        owns_playout_clock: True if the backend itself is responsible for
+            audio playout pacing (e.g. a cascade backend streaming TTS chunks
+            at wall-clock rate), which is required for the barge-in work
+            planned for a later phase. False if playout pacing is delegated
+            to the caller/mediator, or if the backend has no continuous
+            playout concept at all (e.g. a fully end-to-end provider that
+            hands back a finished audio blob).
+    """
+
+    emits_continuous_audio: bool
+    supports_streaming_interruption: bool
+    owns_playout_clock: bool

--- a/src/eva/backend/factory.py
+++ b/src/eva/backend/factory.py
@@ -1,0 +1,55 @@
+"""Factory interface for constructing ``Backend`` instances by name.
+
+DESIGN ONLY (Step 1 of the refactor). Mirrors the shape of today's
+``eva.user_simulator.factory.create_user_simulator`` (lazy per-provider
+imports keyed off config type) but is provider-and-role-agnostic: the same
+factory is meant to be usable to build a backend for either an
+``AssistantRole`` or a ``UserRole``, since a ``Backend`` has no role
+knowledge (that's the whole point of the split -- see docs/refactor-step1.md,
+"lets any backend act as either role").
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from eva.backend.base import Backend
+
+
+class BackendFactory(ABC):
+    """Constructs a ``Backend`` for a named provider from a config blob.
+
+    A concrete implementation is expected to hold (or look up) a registry
+    mapping provider name -> ``Backend`` subclass, analogous to today's
+    ``create_user_simulator`` / assistant-server construction in
+    ``orchestrator/runner.py``, and to import each provider module lazily so
+    that unused providers' SDKs need not be installed/imported.
+    """
+
+    @abstractmethod
+    def create(self, name: str, config: dict[str, Any]) -> Backend:
+        """Construct and return a not-yet-opened ``Backend``.
+
+        Args:
+            name: Provider identifier (e.g. ``"openai_realtime"``,
+                ``"gemini_live"``, ``"elevenlabs"``, ``"cascade"``). The set
+                of valid names is defined by the concrete factory's registry,
+                not by this interface.
+            config: Provider-specific configuration understood by that
+                backend's ``open()`` (see ``Backend.open``). This factory
+                does not validate the shape of ``config`` beyond dispatching
+                on ``name`` -- each ``Backend`` subclass is responsible for
+                validating its own config.
+
+        Returns:
+            A constructed ``Backend`` instance. The returned backend has not
+            had ``open()`` called on it yet -- construction and session
+            establishment are separate steps so a ``Role`` can construct its
+            backend early (e.g. at record setup) and open the session later
+            (e.g. once the other party is ready).
+
+        Raises:
+            ValueError: if ``name`` does not match a known provider.
+        """
+        ...

--- a/src/eva/role/__init__.py
+++ b/src/eva/role/__init__.py
@@ -1,0 +1,17 @@
+"""Provider-agnostic ``Role`` abstraction (design-only, Step 1 of the refactor).
+
+A ``Role`` owns everything that today is duplicated across the assistant and
+user-simulator stacks per-provider: prompt construction, tool ownership, and
+goal/persona/agent-config data. Each ``Role`` holds exactly one
+``eva.backend.Backend`` instance, created at runtime via a
+``eva.backend.BackendFactory``.
+
+Nothing in this package is wired into the existing ``eva.assistant`` /
+``eva.user_simulator`` code yet.
+"""
+
+from eva.role.assistant import AssistantRole
+from eva.role.base import Role
+from eva.role.user import UserRole
+
+__all__ = ["AssistantRole", "Role", "UserRole"]

--- a/src/eva/role/assistant.py
+++ b/src/eva/role/assistant.py
@@ -67,9 +67,12 @@ class AssistantRole(Role):
         current_date_time: str,
         self_nudge_timeout_seconds: float | None = None,
     ) -> None:
-        """See ``Role.__init__`` for the backend-construction args.
+        """Initialize the assistant role.
 
         Args:
+            backend_factory: Factory used to construct the backend.
+            backend_name: Key passed to the factory to select a backend.
+            backend_config: Provider-specific configuration for the backend.
             agent_config_path: Path to the agent YAML (role, instructions,
                 tool schemas) -- mirrors ``AbstractAssistantServer.agent`` /
                 ``agent_config_path``.

--- a/src/eva/role/assistant.py
+++ b/src/eva/role/assistant.py
@@ -1,0 +1,109 @@
+"""``AssistantRole`` contract: the business-side answering role.
+
+DESIGN ONLY (Step 1 of the refactor, see docs/refactor-step1.md). Method
+bodies are stubs; nothing here is wired into the existing code path yet.
+
+Plug-in point (where this will eventually replace existing code):
+    Today the assistant side is a concrete ``AbstractAssistantServer``
+    subclass selected by ``eva.orchestrator.worker._get_server_class(framework)``
+    (worker.py) and constructed + started inside
+    ``ConversationWorker._start_assistant()`` (worker.py), which calls
+    ``server_cls(...).start()``. Its outputs are flushed by
+    ``ConversationWorker._cleanup()`` via ``server.stop()`` (which internally
+    calls ``save_outputs()``), and ``get_conversation_stats()`` /
+    ``get_final_scenario_db()`` are read back in ``ConversationWorker.run()``.
+
+    In a later phase, ``_start_assistant()`` becomes the construction site for
+    an ``AssistantRole`` (framework string -> ``backend_name`` passed to the
+    ``BackendFactory``), and the worker drives ``role.run()`` /
+    ``role.save_outputs()`` / ``role.get_final_scenario_db()`` instead of the
+    server's own lifecycle methods. The provider-specific server subclasses
+    collapse into ``Backend`` implementations behind the factory; the
+    role-agnostic orchestration in ``ConversationWorker`` stays put. This
+    module is deliberately separate from ``eva.role.user`` so that migration
+    can land assistant-side first without touching the user-side diff.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+from eva.backend.factory import BackendFactory
+from eva.role.base import Role
+
+
+class AssistantRole(Role):
+    """Role that answers on behalf of the business (today's "assistant server").
+
+    Carries agent configuration and tool catalog; owns a ``ToolExecutor``
+    (constructed by subclasses, not by this contract) to fulfill
+    ``handle_tool_call_request``.
+
+    Self-nudge: if the caller goes quiet for too long mid-call, the assistant
+    itself proactively re-engages ("are you still there?") rather than
+    waiting forever -- this is assistant-initiated, unlike a caller nudging an
+    unresponsive agent. Unlike the tool-call/idle-detection seams elsewhere in
+    this contract, self-nudging needs no new ``Role`` method and no new
+    ``Backend`` event type: the nudge is just an ordinary outbound turn that
+    this role's backend produces on its own after
+    ``self_nudge_timeout_seconds`` of inactivity, using the same
+    ``system_prompt``/instructions already established at ``open()`` time
+    (see ``Backend.open``'s ``config`` docstring). Whether the *other* side
+    (a ``UserRole``) needs to do anything special upon receiving it, versus
+    just treating it as an ordinary assistant turn through its existing
+    ``run()`` loop, is left open -- see docs/refactor-step1.md discussion;
+    nothing here requires ``UserRole`` changes to handle it correctly today.
+    """
+
+    def __init__(
+        self,
+        *,
+        backend_factory: BackendFactory,
+        backend_name: str,
+        backend_config: dict[str, Any],
+        agent_config_path: str,
+        scenario_db_path: str,
+        current_date_time: str,
+        self_nudge_timeout_seconds: float | None = None,
+    ) -> None:
+        """See ``Role.__init__`` for the backend-construction args.
+
+        Args:
+            agent_config_path: Path to the agent YAML (role, instructions,
+                tool schemas) -- mirrors ``AbstractAssistantServer.agent`` /
+                ``agent_config_path``.
+            scenario_db_path: Path to the per-record scenario database JSON
+                consumed by tool execution -- mirrors
+                ``AbstractAssistantServer.scenario_db_path``.
+            current_date_time: Current date/time string threaded into both
+                prompt construction and tool execution (mirrors existing
+                ``current_date_time`` plumbing throughout the assistant
+                stack).
+            self_nudge_timeout_seconds: How long the assistant backend should
+                wait without hearing from the caller before proactively
+                speaking again, or ``None`` to disable self-nudging entirely.
+                This is an ``AssistantRole``-level knob, not a
+                ``BackendCapabilities`` flag (capabilities describe what a
+                backend *can* do, statically; this is a per-run tuning
+                value). Wiring it into the constructed ``self.backend``'s own
+                config (via ``backend_config`` / ``Backend.open(config=...)``)
+                is left to the concrete subclass's constructor, same as
+                elsewhere in this contract -- a ``Role`` does not otherwise
+                reach into backend config after construction. A backend with
+                no notion of provider-driven idle timing (e.g. a thin
+                end-to-end backend) may simply ignore this value.
+        """
+        super().__init__(backend_factory=backend_factory, backend_name=backend_name, backend_config=backend_config)
+        self.agent_config_path = agent_config_path
+        self.scenario_db_path = scenario_db_path
+        self.current_date_time = current_date_time
+        self.self_nudge_timeout_seconds = self_nudge_timeout_seconds
+
+    @abstractmethod
+    def get_final_scenario_db(self) -> dict[str, Any]:
+        """Return the (possibly mutated) scenario database state, for metrics.
+
+        Mirrors ``AbstractAssistantServer.get_final_scenario_db()``.
+        """
+        ...

--- a/src/eva/role/base.py
+++ b/src/eva/role/base.py
@@ -1,0 +1,159 @@
+"""Abstract ``Role`` base contract: prompt/tools/goal ownership over a ``Backend``.
+
+DESIGN ONLY (Step 1 of the refactor, see docs/refactor-step1.md). Every
+method body here is a stub -- this module defines shapes, not behavior, and
+is not imported by any existing code path.
+
+This module holds only the shared ``Role`` base. The two concrete roles live
+in sibling modules -- ``AssistantRole`` in ``eva.role.assistant`` and
+``UserRole`` in ``eva.role.user`` -- since each carries a meaningfully
+different data payload and plug-in point (see those modules' docstrings) and
+is expected to grow its own implementation in later phases; keeping them in
+separate files keeps each phase's diff scoped to one role.
+
+Design choice -- one ``Role`` base with ``AssistantRole``/``UserRole``
+subclasses, rather than two unrelated ABCs:
+    Both roles share an identical *control loop* shape: construct a backend
+    via ``BackendFactory``, ``build_prompt()`` before opening it, drive
+    ``backend.receive()`` and dispatch tool-call requests to
+    ``handle_tool_call_request()``, and record recorded audio/transcript for
+    output. What differs between them is only the *data* they carry (agent
+    config + tool catalog for the assistant; goal + persona + starting
+    utterance for the user) and how they decide the conversation is over.
+    That's a difference in constructor args and a couple of abstract methods,
+    not in control flow -- so one shared base with two thin subclasses avoids
+    duplicating the event loop, while still keeping tool-ownership and
+    prompt-building role-specific via abstract methods. If the two roles'
+    control loops diverge significantly in a later phase, splitting them
+    apart is a mechanical extraction of ``Role`` into two ABCs -- nothing
+    here should make that harder.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from eva.backend.base import Backend, ToolCallRequest, ToolCallResult
+from eva.backend.factory import BackendFactory
+
+
+class Role(ABC):
+    """Owns prompt, tools/goal, and a runtime-created ``Backend``.
+
+    A ``Role`` is the thing that used to be split across
+    ``AbstractAssistantServer`` (assistant side) and ``AbstractUserSimulator``
+    (user side): everything that is *not* pure provider API exchange lives
+    here instead of in ``Backend``. In particular:
+
+    - Tool execution stays role-side (per docs/refactor-step1.md): a ``Role``
+      is responsible for turning a ``ToolCallRequest`` surfaced by its
+      backend into a ``ToolCallResult``, using whatever execution engine is
+      appropriate for that role (``ToolExecutor`` for ``AssistantRole``; a
+      trivial/no-op handler for ``UserRole``, which today only exposes a
+      synthetic ``end_call`` tool). ``Backend`` implementations never
+      execute tools themselves.
+    - Prompt construction stays role-side: ``build_prompt()`` replaces both
+      ``AbstractAssistantServer._build_system_prompt()`` /
+      ``AgenticSystem``'s prompt building and
+      ``AbstractUserSimulator._build_prompt()``.
+    - Audio recording / output persistence is a role-side concern shared by
+      both subclasses (see ``docs/refactor-step1.md`` point 5, "consolidate
+      audio recording / output-saving into one shared helper") -- this base
+      class declares the seam (``record_audio`` / ``save_outputs``) but does
+      not implement the shared helper itself; that helper is later work.
+    """
+
+    def __init__(self, *, backend_factory: BackendFactory, backend_name: str, backend_config: dict[str, Any]) -> None:
+        """Construct the role's backend (but do not open its session yet).
+
+        Args:
+            backend_factory: Factory used to construct ``self.backend``.
+            backend_name: Provider name passed through to
+                ``BackendFactory.create``.
+            backend_config: Provider-specific config passed through to
+                ``BackendFactory.create`` (not to be confused with the
+                ``config`` argument of ``Backend.open``, which is also
+                provider-specific but may be augmented by the role at
+                open-time, e.g. with a resolved sample rate).
+        """
+        self.backend: Backend = backend_factory.create(backend_name, backend_config)
+
+    @abstractmethod
+    def build_prompt(self) -> str:
+        """Build the full system prompt / instructions for this role.
+
+        For ``AssistantRole`` this replaces
+        ``AbstractAssistantServer._build_system_prompt()`` and
+        ``AgenticSystem``'s inline prompt construction. For ``UserRole`` this
+        replaces ``AbstractUserSimulator._build_prompt()``. Called before
+        ``Backend.open()`` so the result can be passed as its
+        ``system_prompt`` argument.
+        """
+        ...
+
+    @abstractmethod
+    async def handle_tool_call_request(self, request: ToolCallRequest) -> ToolCallResult:
+        """Execute a tool call surfaced by this role's backend and return the result.
+
+        This is the single place tool execution happens for this role --
+        ``Backend`` implementations must never execute tools directly (see
+        class docstring). Implementations should log the call/result (e.g.
+        to an audit log) as part of executing it.
+        """
+        ...
+
+    @abstractmethod
+    async def run(self) -> str:
+        """Drive the conversation for this role until it reaches a terminal state.
+
+        Expected shape (left to subclasses to implement, not prescribed in
+        detail here since the exact loop depends on the backend's
+        capabilities -- see ``BackendCapabilities``):
+        1. ``await self.backend.open(system_prompt=self.build_prompt(), ...)``
+        2. Iterate ``self.backend.receive()``, dispatching
+           ``TOOL_CALL_REQUEST`` events to ``handle_tool_call_request`` and
+           feeding the ``ToolCallResult`` back via
+           ``self.backend.send(tool_result=...)``.
+        3. Record audio/transcript events as they arrive (see
+           ``record_audio``).
+        4. On a terminal event (hangup, timeout, transfer, error), call
+           ``await self.backend.close()`` and return an end-reason string.
+
+        Returns:
+            A short end-reason string (e.g. ``"goodbye"``, ``"transfer"``,
+            ``"timeout"``, ``"error"``) -- mirrors the return contract of
+            today's ``AbstractUserSimulator.run_conversation()``.
+        """
+        ...
+
+    @abstractmethod
+    def record_audio(self, source: str, audio_data: bytes) -> None:
+        """Accumulate a chunk of audio for later persistence.
+
+        Args:
+            source: Role-defined stream label (e.g. ``"user"``,
+                ``"assistant"``, or a cleaned/pre-perturbation variant).
+                Mirrors ``AbstractUserSimulator._record_audio`` /
+                ``AbstractAssistantServer``'s audio-buffer fields; the exact
+                set of valid labels is left to subclasses/shared helper, not
+                fixed by this contract.
+            audio_data: Raw PCM16 bytes at this role's recording sample rate.
+        """
+        ...
+
+    @abstractmethod
+    async def save_outputs(self, output_dir: Path) -> None:
+        """Persist this role's output artifacts to ``output_dir``.
+
+        For ``AssistantRole`` this covers ``audit_log.json``,
+        ``transcript.jsonl``, scenario DB snapshots (mirrors
+        ``AbstractAssistantServer.save_outputs``). For ``UserRole`` this
+        covers ``user_simulator_events.jsonl`` (mirrors the event logger in
+        ``AbstractUserSimulator``). Audio WAV files are expected to be
+        written by the shared audio-recording helper referenced in
+        ``record_audio``, not necessarily by this method -- exact division of
+        labor is left to the later implementation phase.
+        """
+        ...

--- a/src/eva/role/user.py
+++ b/src/eva/role/user.py
@@ -1,0 +1,80 @@
+"""``UserRole`` contract: the simulated-caller role.
+
+DESIGN ONLY (Step 1 of the refactor, see docs/refactor-step1.md). Method
+bodies are stubs; nothing here is wired into the existing code path yet.
+
+Plug-in point (where this will eventually replace existing code):
+    Today the user side is a concrete ``AbstractUserSimulator`` subclass
+    selected by ``eva.user_simulator.factory.create_user_simulator(config, ...)``
+    and constructed inside ``ConversationWorker._start_user_simulator()``
+    (worker.py), which passes it ``server_url=f"ws://localhost:{port}/ws"``
+    to reach the assistant server. The conversation is driven by
+    ``ConversationWorker._run_conversation()`` calling
+    ``user_simulator.run_conversation()``, whose returned end-reason string
+    becomes the conversation result.
+
+    In a later phase, ``_start_user_simulator()`` becomes the construction
+    site for a ``UserRole`` (simulator config -> ``backend_name`` +
+    ``backend_config`` for the ``BackendFactory``), and the worker drives
+    ``role.run()`` (returning the same end-reason string via
+    ``get_end_reason()``) instead of ``run_conversation()``. Note the
+    ``server_url`` handoff is a *transport* detail that today's user side owns
+    directly; per docs/refactor-step1.md the ``Backend`` contract is kept
+    direction-agnostic precisely so this WS-connect concern can move into a
+    ``Backend`` implementation (or, later, a mediator) without the role
+    caring. This module is deliberately separate from ``eva.role.assistant``
+    so the user-side migration can land as its own scoped diff.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+from eva.backend.factory import BackendFactory
+from eva.role.base import Role
+
+
+class UserRole(Role):
+    """Role that simulates the human caller (today's "user simulator").
+
+    Carries goal/persona instead of agent config/tools -- its tool surface,
+    if any, is limited to caller-side affordances like ``end_call`` (see
+    ``END_CALL_DESCRIPTION`` in today's ``eva.user_simulator.base``), not a
+    business tool catalog.
+    """
+
+    def __init__(
+        self,
+        *,
+        backend_factory: BackendFactory,
+        backend_name: str,
+        backend_config: dict[str, Any],
+        goal: dict[str, Any],
+        persona_config: dict[str, Any],
+        current_date_time: str,
+    ) -> None:
+        """See ``Role.__init__`` for the backend-construction args.
+
+        Args:
+            goal: User goal / decision-tree data -- mirrors
+                ``AbstractUserSimulator.goal``.
+            persona_config: Persona/voice/behavior configuration -- mirrors
+                ``AbstractUserSimulator.persona_config``.
+            current_date_time: Threaded into prompt construction, mirroring
+                existing plumbing.
+        """
+        super().__init__(backend_factory=backend_factory, backend_name=backend_name, backend_config=backend_config)
+        self.goal = goal
+        self.persona_config = persona_config
+        self.current_date_time = current_date_time
+
+    @abstractmethod
+    def get_end_reason(self) -> str:
+        """Return the terminal end-reason for this conversation.
+
+        Mirrors the return value of today's
+        ``AbstractUserSimulator.run_conversation()`` (``"goodbye"``,
+        ``"transfer"``, ``"timeout"``, ``"error"``, ...).
+        """
+        ...

--- a/src/eva/role/user.py
+++ b/src/eva/role/user.py
@@ -54,9 +54,12 @@ class UserRole(Role):
         persona_config: dict[str, Any],
         current_date_time: str,
     ) -> None:
-        """See ``Role.__init__`` for the backend-construction args.
+        """Initialize the user role.
 
         Args:
+            backend_factory: Factory used to construct the backend.
+            backend_name: Key passed to the factory to select a backend.
+            backend_config: Provider-specific configuration for the backend.
             goal: User goal / decision-tree data -- mirrors
                 ``AbstractUserSimulator.goal``.
             persona_config: Persona/voice/behavior configuration -- mirrors


### PR DESCRIPTION
Simple empty boilerplate for refactor, mainly to show what will happen + smaller diff for the big change

next PR follow up: refactor openai realtime into this paradigm, easiest to start. This will include the full development of the user and assistant roles, but only 1 backend (less to review for the initial concept)

All other backend migration will follow after that