### PR TITLE
Make assistant nudge user if they are silent for > n seconds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,14 @@ EVA_MODEL_LIST='[
 #r 30,10000,10
 #v EVA_CONVERSATION_TIME_LIMIT_SECONDS=600
 
+#i Seconds of user silence after the assistant stops speaking before nudging it to retry the
+#i turn (cascade/pipecat framework; VAD-driven, so it never fires while the user is speaking).
+#i Leave unset to keep the old behavior of ending the conversation once the provider's
+#i inactivity timeout elapses.
+#d int
+#r 1,120,1
+#v EVA_TURN_END_FALLBACK_TIME=
+
 #i Maximum rerun attempts for failed records.
 #d int
 #r 0,20,1

--- a/.env.example
+++ b/.env.example
@@ -198,8 +198,9 @@ EVA_MODEL_LIST='[
 #r 30,10000,10
 #v EVA_CONVERSATION_TIME_LIMIT_SECONDS=600
 
-#i Seconds of user silence after the assistant stops speaking before nudging it to retry the
-#i turn (cascade/pipecat framework; VAD-driven, so it never fires while the user is speaking).
+#i Seconds of user silence after the assistant stops speaking before nudging it to reprompt
+#i the caller (Pipecat cascade + audio-LLM pipelines). Cancelled the moment the user starts
+#i speaking, so it only fires on genuine silence when turn detection drops a user turn.
 #i Leave unset to keep the old behavior of ending the conversation once the provider's
 #i inactivity timeout elapses.
 #d int

--- a/docs/metrics/turn_taking.md
+++ b/docs/metrics/turn_taking.md
@@ -19,6 +19,7 @@ Code-based metric (no LLM) that scores each user→assistant transition on a con
 - `latency_assistant_turns` — per-turn latency (`first_asst_start - last_user_end`) in seconds. Drives the latency curve.
 - `assistant_interrupted_turns` / `user_interrupted_turns` — turn-level interruption flags set by the processor.
 - `conversation_trace` — used to detect which turns contain a tool call (`type == "tool_call"`). Tool-call turns get a more lenient upper end of the latency curve and a higher `late` threshold, since tool execution adds inherent latency.
+- `output_dir` — read directly (not via `conversation_trace`) to load `audit_log.json` for the `pretoolspeech_rate` sub-metric (see below).
 
 ## Per-turn Score
 
@@ -189,7 +190,26 @@ Sub-metric aggregation reads the raw per-turn values from `per_turn_evidence` ra
 | `user_interruption.mean_yield_ms` | no | rate > 0 | Arithmetic mean of `yield_ms` across user-interrupt turns. |
 | `user_interruption.mean_yield_score` | yes | rate > 0 | Mean of the per-turn yield scores that feed the main score. |
 
-Rate sub-metrics are emitted as `normalized_score` (they already live on `[0, 1]`). Raw-ms sub-metrics have `normalized_score = None` so they don't corrupt cross-metric averages.
+**Turn-end fallback nudges**
+
+| Key | Normalized? | When present | Meaning |
+| --- | --- | --- | --- |
+| `fallback_nudge.rate` | yes | at least one assistant turn | `len(fallback_turn_ids) / total_assistant_turns`. Denominator is all assistant turns (`audio_timestamps_assistant_turns`), not the evaluable-turn count, since a fallback nudge produces an assistant turn with no paired user turn and so is never in the evaluable set. |
+| `fallback_nudge.count` | no (raw count) | always, but `score=None` when zero | Total number of fallback-nudge turns. `None` on clean runs so cross-record aggregates exclude them rather than averaging in zeros. |
+
+**Pre-tool-speech lead-in rate**
+
+| Key | Normalized? | When present | Meaning |
+| --- | --- | --- | --- |
+| `pretoolspeech_rate` | yes | at least one tool-call group and `audit_log.json` is readable | Fraction of tool-call groups preceded by a non-empty assistant utterance since the previous group ended (or since the conversation started). Measures how often the agent gives a spoken lead-in (per `agent.pre_tool_speech` in `configs/prompts/simulation.yaml`) before invoking a tool. |
+
+Computed by `_compute_pre_tool_speech_groups`, which reads `audit_log.json` directly from `context.output_dir` **instead of** `conversation_trace`. A "tool-call group" is a maximal contiguous run of `tool_call`/`tool_response` entries in the raw audit-log transcript (sorted by `timestamp`) — consecutive tool calls fired off one lead-in (e.g. two tools called back-to-back with no intervening speech) count as a single group, matching the prompt's "one lead-in per batch" instruction. Assistant speech only counts if it has non-empty, non-whitespace content; a `user` event resets the "spoke since last group" flag so a lead-in from a previous turn can't be credited to a later turn's tool calls. Event types other than `assistant`/`user`/`tool_call`/`tool_response` (e.g. `llm_call`) are ignored rather than treated as group-breaking — see the regression test guarding this.
+
+**Why not `conversation_trace`?** For S2S, `conversation_trace` assistant entries come from the user simulator's STT transcription of the spoken audio, timestamped only after the audio finishes playing — not the audit log's true (early) LLM-generation timestamp used to build the trace for cascade/audio-LLM. That transcription can sort *after* a subsequent tool call in the timestamp-ordered trace even when the agent actually spoke first (confirmed against a real S2S transcript), so trace order can't be trusted for this signal on S2S. Reading `audit_log.json` directly sidesteps the issue and gives one code path across cascade, S2S, and audio-LLM.
+
+`pretoolspeech_rate` is omitted (not emitted) when there are no tool-call groups, or when `audit_log.json` is missing/unreadable/empty at `context.output_dir` — treated as "unknown", not "no lead-ins".
+
+Rate sub-metrics are emitted as `normalized_score` (they already live on `[0, 1]`). Raw-ms/count sub-metrics have `normalized_score = None` so they don't corrupt cross-metric averages.
 
 ## Tunable Constants
 

--- a/src/eva/assistant/agentic/audio_llm_system.py
+++ b/src/eva/assistant/agentic/audio_llm_system.py
@@ -72,6 +72,9 @@ class AudioLLMAgenticSystem(AgenticSystem):
 
         # Per-turn audio history: list of (audio_bytes, sample_rate)
         self._turn_audio_history: list[tuple[bytes, int]] = []
+        # Optional text prepended to the current turn's audio message (consumed once). Used by the
+        # turn-end fallback to have the model acknowledge it may not have heard the audio perfectly.
+        self._turn_text_hint: str = ""
 
     def set_turn_audio(self, audio_bytes: bytes, sample_rate: int) -> None:
         """Record audio data for the current user turn.
@@ -80,6 +83,14 @@ class AudioLLMAgenticSystem(AgenticSystem):
         Audio is appended to the history and retained for all future LLM calls.
         """
         self._turn_audio_history.append((audio_bytes, sample_rate))
+
+    def set_turn_text_hint(self, hint: str) -> None:
+        """Set a text hint prepended to the next audio user message (consumed once).
+
+        Used by the turn-end fallback so the model is told the audio may be incomplete /
+        imperfectly heard and should acknowledge that before answering.
+        """
+        self._turn_text_hint = hint
 
     async def process_query_with_audio(self, user_text: str) -> AsyncGenerator[str, None]:
         """Process a user turn that has audio data.
@@ -120,6 +131,11 @@ class AudioLLMAgenticSystem(AgenticSystem):
         conversation_history = self.audit_log.get_conversation_messages(max_messages=30)
         history_dicts = [msg.to_dict() for msg in conversation_history]
 
+        # Text hint for the CURRENT turn's audio (e.g. a turn-end fallback acknowledgment).
+        # Consumed once so it only applies to this turn.
+        turn_text_hint = self._turn_text_hint
+        self._turn_text_hint = ""
+
         if self._turn_audio_history:
             if self.full_audio_context:
                 # Replace ALL user messages with their corresponding audio
@@ -127,9 +143,12 @@ class AudioLLMAgenticSystem(AgenticSystem):
                 for turn_idx, msg_idx in enumerate(user_indices):
                     if turn_idx < len(self._turn_audio_history):
                         audio_bytes, sample_rate = self._turn_audio_history[turn_idx]
+                        # Only the current (last) turn gets the hint.
+                        hint = turn_text_hint if turn_idx == len(user_indices) - 1 else ""
                         history_dicts[msg_idx] = self.alm_client.build_audio_user_message(
                             audio_bytes=audio_bytes,
                             source_sample_rate=sample_rate,
+                            text_hint=hint,
                         )
             else:
                 # Replace only the LAST user message with audio (current turn)
@@ -144,6 +163,7 @@ class AudioLLMAgenticSystem(AgenticSystem):
                     history_dicts[last_user_idx] = self.alm_client.build_audio_user_message(
                         audio_bytes=audio_bytes,
                         source_sample_rate=sample_rate,
+                        text_hint=turn_text_hint,
                     )
 
         messages.extend(history_dicts)

--- a/src/eva/assistant/agentic/audio_llm_system.py
+++ b/src/eva/assistant/agentic/audio_llm_system.py
@@ -39,6 +39,7 @@ class AudioLLMAgenticSystem(AgenticSystem):
         audit_log: AuditLog,
         alm_client: BaseALMClient,
         output_dir: Path | None = None,
+        pre_tool_speech: str = "off",
         llm_streaming: bool = False,
         full_audio_context: bool = False,
     ):
@@ -49,6 +50,7 @@ class AudioLLMAgenticSystem(AgenticSystem):
             audit_log=audit_log,
             llm_client=alm_client,
             output_dir=output_dir,
+            pre_tool_speech=pre_tool_speech,
             llm_streaming=llm_streaming,
         )
         self.alm_client: BaseALMClient = alm_client
@@ -64,6 +66,9 @@ class AudioLLMAgenticSystem(AgenticSystem):
             agent_instructions=agent.instructions,
             datetime=current_date_time,
         )
+        # Reuse the shared pre-tool lead-in prompt appended to the system prompt.
+        if self.pre_tool_speech == "auto":
+            self.system_prompt += "\n\n" + self.prompt_manager.get_prompt("agent.pre_tool_speech")
 
         # Per-turn audio history: list of (audio_bytes, sample_rate)
         self._turn_audio_history: list[tuple[bytes, int]] = []

--- a/src/eva/assistant/agentic/audio_llm_system.py
+++ b/src/eva/assistant/agentic/audio_llm_system.py
@@ -71,7 +71,11 @@ class AudioLLMAgenticSystem(AgenticSystem):
             self.system_prompt += "\n\n" + self.prompt_manager.get_prompt("agent.pre_tool_speech")
 
         # Per-turn audio history: list of (audio_bytes, sample_rate)
-        self._turn_audio_history: list[tuple[bytes, int]] = []
+        # One entry per user turn, aligned 1:1 with the user messages in the conversation history
+        # so full_audio_context maps audio to the right turn. The user can only speak audio, but a
+        # turn may carry no audio (genuine silence hitting the turn-end fallback); that turn is
+        # recorded as ``None`` so the reprompt stays text and later turns' audio doesn't shift.
+        self._turn_audio_history: list[tuple[bytes, int] | None] = []
         # Optional text prepended to the current turn's audio message (consumed once). Used by the
         # turn-end fallback to have the model acknowledge it may not have heard the audio perfectly.
         self._turn_text_hint: str = ""
@@ -83,6 +87,14 @@ class AudioLLMAgenticSystem(AgenticSystem):
         Audio is appended to the history and retained for all future LLM calls.
         """
         self._turn_audio_history.append((audio_bytes, sample_rate))
+
+    def note_non_audio_turn(self) -> None:
+        """Record a user turn that carried no audio (genuine silence hitting the turn-end fallback).
+
+        Keeps ``_turn_audio_history`` aligned 1:1 with user messages so ``full_audio_context``
+        maps audio to the correct turns; this turn stays as its text reprompt in the prompt.
+        """
+        self._turn_audio_history.append(None)
 
     def set_turn_text_hint(self, hint: str) -> None:
         """Set a text hint prepended to the next audio user message (consumed once).
@@ -138,18 +150,24 @@ class AudioLLMAgenticSystem(AgenticSystem):
 
         if self._turn_audio_history:
             if self.full_audio_context:
-                # Replace ALL user messages with their corresponding audio
+                # Replace each user message with its corresponding audio. _turn_audio_history is
+                # aligned 1:1 with user messages; a None entry is a no-audio turn (silence hit the
+                # fallback), so it's left as its text reprompt and audio stays on the right turn.
                 user_indices = [i for i, msg in enumerate(history_dicts) if msg.get("role") == "user"]
                 for turn_idx, msg_idx in enumerate(user_indices):
-                    if turn_idx < len(self._turn_audio_history):
-                        audio_bytes, sample_rate = self._turn_audio_history[turn_idx]
-                        # Only the current (last) turn gets the hint.
-                        hint = turn_text_hint if turn_idx == len(user_indices) - 1 else ""
-                        history_dicts[msg_idx] = self.alm_client.build_audio_user_message(
-                            audio_bytes=audio_bytes,
-                            source_sample_rate=sample_rate,
-                            text_hint=hint,
-                        )
+                    if turn_idx >= len(self._turn_audio_history):
+                        break
+                    entry = self._turn_audio_history[turn_idx]
+                    if entry is None:
+                        continue  # no-audio turn stays as text
+                    audio_bytes, sample_rate = entry
+                    # Only the current (last) turn gets the hint.
+                    hint = turn_text_hint if turn_idx == len(user_indices) - 1 else ""
+                    history_dicts[msg_idx] = self.alm_client.build_audio_user_message(
+                        audio_bytes=audio_bytes,
+                        source_sample_rate=sample_rate,
+                        text_hint=hint,
+                    )
             else:
                 # Replace only the LAST user message with audio (current turn)
                 last_user_idx = None
@@ -158,8 +176,9 @@ class AudioLLMAgenticSystem(AgenticSystem):
                         last_user_idx = i
                         break
 
-                if last_user_idx is not None:
-                    audio_bytes, sample_rate = self._turn_audio_history[-1]
+                entry = self._turn_audio_history[-1]
+                if last_user_idx is not None and entry is not None:
+                    audio_bytes, sample_rate = entry
                     history_dicts[last_user_idx] = self.alm_client.build_audio_user_message(
                         audio_bytes=audio_bytes,
                         source_sample_rate=sample_rate,

--- a/src/eva/assistant/agentic/audit_log.py
+++ b/src/eva/assistant/agentic/audit_log.py
@@ -96,11 +96,13 @@ class AuditLog:
         content: str,
         timestamp_ms: str | None = None,
         turn_id: int | None = None,
+        message_type: str = "user",
+        llm_content: str | None = None,
     ) -> None:
         """Record user input.
 
         Args:
-            content: User message text.
+            content: User message text, as recorded in the transcript/audit log.
             timestamp_ms: Epoch-millisecond string to use as the entry
                 timestamp.  When *None* (default), ``current_timestamp_ms()``
                 is used.  The realtime instrumented LLM service passes the
@@ -109,6 +111,12 @@ class AuditLog:
             turn_id: Optional turn identifier for associating transcription
                 updates with the correct entry when transcription runs in
                 parallel with processing.
+            message_type: Transcript entry type, e.g. "user" (default) or
+                "turn_fallback" for a synthetic turn-end fallback nudge, so
+                downstream metrics can identify and skip/zero it.
+            llm_content: When set, used as the message sent to the LLM instead of
+                ``content``. Lets the audit log show a plain marker while the LLM
+                sees a more instructive prompt (e.g. a turn-end fallback nudge).
         """
         entry = {
             "value": content,
@@ -116,17 +124,22 @@ class AuditLog:
             "type": "text",
             "isBotMessage": False,
             "timestamp": timestamp_ms or current_timestamp_ms(),
-            "message_type": "user",
+            "message_type": message_type,
         }
         if turn_id is not None:
             entry["turn_id"] = turn_id
+        # When the transcript value differs from what the model actually received (e.g. a
+        # turn-end fallback marker vs. the nudge + partial context), record the sent text so
+        # the audit log captures exactly what context was forwarded to the model.
+        if llm_content is not None:
+            entry["llm_content"] = llm_content
         self.transcript.append(entry)
 
         # Also add to conversation messages (with turn_id for matching)
         self.conversation_messages.append(
             ConversationMessage(
                 role=MessageRole.USER,
-                content=content,
+                content=llm_content if llm_content is not None else content,
                 turn_id=turn_id,
             )
         )

--- a/src/eva/assistant/agentic/system.py
+++ b/src/eva/assistant/agentic/system.py
@@ -153,7 +153,7 @@ class AgenticSystem:
         logger.info(f"Recording partial streamed assistant output after {reason}")
         self.audit_log.append_assistant_output(partial)
 
-    async def process_query(self, query: str) -> AsyncGenerator[str, None]:
+    async def process_query(self, query: str, log_user_input: bool = True) -> AsyncGenerator[str, None]:
         """Process a user query and yield response messages.
 
         This is the main entry point for handling user input.
@@ -161,6 +161,10 @@ class AgenticSystem:
 
         Args:
             query: User's input text
+            log_user_input: Whether to record `query` as a user_input audit log entry.
+                Set to False when the caller already logged its own marker entry for this
+                turn (e.g. a turn-end fallback nudge) and only wants the LLM call driven
+                by `query` without a duplicate audit log entry.
 
         Yields:
             Text responses to be sent to TTS
@@ -168,7 +172,8 @@ class AgenticSystem:
         logger.info(f"Processing query: {query}")
 
         # Record user input
-        self.audit_log.append_user_input(query)
+        if log_user_input:
+            self.audit_log.append_user_input(query)
 
         # Execute agent interaction
         async for response in self._execute_agent(self.agent):

--- a/src/eva/assistant/base_server.py
+++ b/src/eva/assistant/base_server.py
@@ -117,6 +117,24 @@ class AbstractAssistantServer(ABC):
         """
         ...
 
+    def notify_conversation_ending(self, reason: str | None = None) -> None:
+        """Tell the assistant the conversation is over, ahead of transport teardown.
+
+        The user simulator calls this the moment it knows the call has ended (``end_call``,
+        timeout, or error) — *before* its STT grace period and any post-hoc API polling, which
+        together can hold the WebSocket open for 10s or more. Without this early signal the
+        assistant only learns of the end via transport disconnect, long enough after the fact
+        that silence-triggered behavior (e.g. the turn-end fallback nudge) can fire into an
+        already-closed conversation.
+
+        Default is a no-op: only frameworks with such behavior need to react. Must be safe to
+        call more than once, and must not raise — teardown paths call it best-effort.
+
+        Args:
+            reason: End reason if known (``"goodbye"``, ``"timeout"``, ``"error"``), for logging.
+        """
+        return None
+
     async def stop(self) -> asyncio.Task | None:
         """Stop the server: shut down framework, extract audio, save outputs.
 

--- a/src/eva/assistant/pipecat_server.py
+++ b/src/eva/assistant/pipecat_server.py
@@ -372,6 +372,7 @@ class PipecatAssistantServer(AbstractAssistantServer):
                     alm_client=alm_client,
                     audio_collector=audio_llm_audio_collector,
                     output_dir=self.output_dir,
+                    pre_tool_speech=self.pipeline_config.pre_tool_speech,
                     llm_streaming=self.pipeline_config.llm_streaming,
                     full_audio_context=self.pipeline_config.audio_llm_params.get("full_audio_context", False),
                 )

--- a/src/eva/assistant/pipecat_server.py
+++ b/src/eva/assistant/pipecat_server.py
@@ -456,6 +456,7 @@ class PipecatAssistantServer(AbstractAssistantServer):
                 audio_llm_audio_collector=audio_llm_audio_collector,
                 input_transcription_context_filter=input_transcription_context_filter,
                 input_transcription_processor=input_transcription_processor,
+                turn_stop_strategy=turn_stop_strategy,
             )
 
             metrics_log_path = self.output_dir / "pipecat_metrics.jsonl"
@@ -576,6 +577,7 @@ class PipecatAssistantServer(AbstractAssistantServer):
         audio_llm_audio_collector=None,
         input_transcription_context_filter=None,
         input_transcription_processor=None,
+        turn_stop_strategy=None,
     ) -> Pipeline:
         """Create the Pipecat pipeline.
 
@@ -598,6 +600,8 @@ class PipecatAssistantServer(AbstractAssistantServer):
                 UserObserver(
                     turn_end_fallback_time=self.turn_end_fallback_time,
                     fallback_processor=agent_processor,
+                    # Cascade: fallback rides the standard turn flow via a native turn-stop.
+                    turn_stop_strategy=turn_stop_strategy,
                 )
             )
             pipeline_components.append(user_aggregator)  # Aggregates & fires turn events

--- a/src/eva/assistant/pipecat_server.py
+++ b/src/eva/assistant/pipecat_server.py
@@ -99,6 +99,7 @@ class PipecatAssistantServer(AbstractAssistantServer):
         port: int,
         conversation_id: str,
         language: str = "en",
+        turn_end_fallback_time: int | None = None,
     ):
         """Initialize the assistant server.
 
@@ -112,6 +113,8 @@ class PipecatAssistantServer(AbstractAssistantServer):
             port: Port to listen on
             conversation_id: Unique ID for this conversation
             language: BCP 47 language tag for STT/TTS services (e.g. 'en', 'fr', 'es-MX')
+            turn_end_fallback_time: Seconds of user-turn silence after the assistant stops
+                speaking before nudging it to retry. ``None`` disables the fallback.
         """
         super().__init__(
             current_date_time=current_date_time,
@@ -126,6 +129,7 @@ class PipecatAssistantServer(AbstractAssistantServer):
         )
 
         self.agentic_system = None  # Will be set in _handle_session
+        self.turn_end_fallback_time = turn_end_fallback_time
 
         # Wall-clock captured at on_user_turn_started for non-instrumented S2S models
         self._user_turn_started_wall_ms: str | None = None
@@ -422,6 +426,7 @@ class PipecatAssistantServer(AbstractAssistantServer):
                     output_dir=self.output_dir,
                     pre_tool_speech=self.pipeline_config.pre_tool_speech,
                     llm_streaming=self.pipeline_config.llm_streaming,
+                    turn_end_fallback_time=self.turn_end_fallback_time,
                 )
 
                 async def on_assistant_response(msg: str) -> None:

--- a/src/eva/assistant/pipecat_server.py
+++ b/src/eva/assistant/pipecat_server.py
@@ -427,7 +427,6 @@ class PipecatAssistantServer(AbstractAssistantServer):
                     output_dir=self.output_dir,
                     pre_tool_speech=self.pipeline_config.pre_tool_speech,
                     llm_streaming=self.pipeline_config.llm_streaming,
-                    turn_end_fallback_time=self.turn_end_fallback_time,
                 )
 
                 async def on_assistant_response(msg: str) -> None:
@@ -592,14 +591,26 @@ class PipecatAssistantServer(AbstractAssistantServer):
             pipeline_components.append(stt)
             # CRITICAL ORDER: Processors that need to SEE frames must come BEFORE user_aggregator
             # because user_aggregator CONSUMES frames (doesn't pass through)
-            pipeline_components.append(UserObserver())  # For metrics
+            # UserObserver also hosts the turn-end fallback timer (arms/cancels on the bot/user
+            # speaking frames it sees here on the spine) and drives agent_processor's nudge.
+            pipeline_components.append(
+                UserObserver(
+                    turn_end_fallback_time=self.turn_end_fallback_time,
+                    fallback_processor=agent_processor,
+                )
+            )
             pipeline_components.append(user_aggregator)  # Aggregates & fires turn events
             # Add agent processor (receives turn events via event handler)
             pipeline_components.append(agent_processor)
         elif audio_llm_processor:
             # Audio-LLM pipeline: collector buffers audio, processor handles turns
             pipeline_components.append(audio_llm_audio_collector)  # Buffers audio frames
-            pipeline_components.append(UserObserver())  # For metrics
+            pipeline_components.append(
+                UserObserver(
+                    turn_end_fallback_time=self.turn_end_fallback_time,
+                    fallback_processor=audio_llm_processor,
+                )
+            )
             pipeline_components.append(user_aggregator)  # Aggregates & fires turn events
             pipeline_components.append(
                 ParallelPipeline(

--- a/src/eva/assistant/pipecat_server.py
+++ b/src/eva/assistant/pipecat_server.py
@@ -131,6 +131,10 @@ class PipecatAssistantServer(AbstractAssistantServer):
         self.agentic_system = None  # Will be set in _handle_session
         self.turn_end_fallback_time = turn_end_fallback_time
 
+        # Set in _create_pipeline for the cascade / audio-LLM flavors; hosts the turn-end
+        # fallback timer so notify_conversation_ending() can latch it off at session end.
+        self._user_observer: UserObserver | None = None
+
         # Wall-clock captured at on_user_turn_started for non-instrumented S2S models
         self._user_turn_started_wall_ms: str | None = None
 
@@ -190,6 +194,18 @@ class PipecatAssistantServer(AbstractAssistantServer):
             await asyncio.sleep(0.01)
 
         logger.info(f"Assistant server started on ws://localhost:{self.port}")
+
+    def notify_conversation_ending(self, reason: str | None = None) -> None:
+        """Latch the turn-end fallback off as soon as the simulator knows the call ended.
+
+        See ``AbstractAssistantServer.notify_conversation_ending``. The pipeline's own
+        End/Cancel handling also latches the fallback, but that only arrives on transport
+        disconnect — after the simulator's STT grace period and end_call API polling, by which
+        point a 10s nudge timer armed on the assistant's last utterance has already fired.
+        """
+        if self._user_observer is not None:
+            self._user_observer.shutdown_fallback()
+            logger.debug(f"Turn-end fallback disarmed: conversation ending (reason: {reason})")
 
     async def _shutdown(self) -> None:
         """Stop the Pipecat pipeline and uvicorn server."""
@@ -596,26 +612,24 @@ class PipecatAssistantServer(AbstractAssistantServer):
             # because user_aggregator CONSUMES frames (doesn't pass through)
             # UserObserver also hosts the turn-end fallback timer (arms/cancels on the bot/user
             # speaking frames it sees here on the spine) and drives agent_processor's nudge.
-            pipeline_components.append(
-                UserObserver(
-                    turn_end_fallback_time=self.turn_end_fallback_time,
-                    fallback_processor=agent_processor,
-                    # Cascade: fallback rides the standard turn flow via a native turn-stop.
-                    turn_stop_strategy=turn_stop_strategy,
-                )
+            self._user_observer = UserObserver(
+                turn_end_fallback_time=self.turn_end_fallback_time,
+                fallback_processor=agent_processor,
+                # Cascade: fallback rides the standard turn flow via a native turn-stop.
+                turn_stop_strategy=turn_stop_strategy,
             )
+            pipeline_components.append(self._user_observer)
             pipeline_components.append(user_aggregator)  # Aggregates & fires turn events
             # Add agent processor (receives turn events via event handler)
             pipeline_components.append(agent_processor)
         elif audio_llm_processor:
             # Audio-LLM pipeline: collector buffers audio, processor handles turns
             pipeline_components.append(audio_llm_audio_collector)  # Buffers audio frames
-            pipeline_components.append(
-                UserObserver(
-                    turn_end_fallback_time=self.turn_end_fallback_time,
-                    fallback_processor=audio_llm_processor,
-                )
+            self._user_observer = UserObserver(
+                turn_end_fallback_time=self.turn_end_fallback_time,
+                fallback_processor=audio_llm_processor,
             )
+            pipeline_components.append(self._user_observer)
             pipeline_components.append(user_aggregator)  # Aggregates & fires turn events
             pipeline_components.append(
                 ParallelPipeline(

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -64,6 +64,7 @@ class BenchmarkAgentProcessor(FrameProcessor):
         output_dir=None,
         pre_tool_speech: str = "off",
         llm_streaming: bool = False,
+        turn_end_fallback_time: int | None = None,
         **kwargs,
     ) -> None:
         """Initialize the agent processor.
@@ -77,6 +78,9 @@ class BenchmarkAgentProcessor(FrameProcessor):
             output_dir: Optional output directory for saving performance stats
             pre_tool_speech: Lead-in mode ('off'|'auto')
             llm_streaming: Stream LLM output sentence-by-sentence
+            turn_end_fallback_time: Seconds of silence after the assistant stops speaking
+                before nudging it to retry (VAD-driven). ``None`` disables the fallback and
+                preserves the old behavior of waiting for the provider's inactivity timeout.
             **kwargs: Additional keyword arguments passed to FrameProcessor
         """
         super().__init__(**kwargs)
@@ -105,6 +109,19 @@ class BenchmarkAgentProcessor(FrameProcessor):
         self._user_speaking = False
         self._bot_speaking = False
 
+        # Turn-end fallback: a fresh timer is armed each time the assistant stops speaking
+        # and fires `turn_end_fallback_time` seconds later REGARDLESS of what VAD reports.
+        # The fallback exists precisely for when VAD is wrong (e.g. it never closes the
+        # user's turn), so it deliberately does not defer to VAD speech-start signals.
+        self._turn_end_fallback_time = turn_end_fallback_time
+        self._fallback_timer_task: asyncio.Task | None = None
+        self._consecutive_fallback_nudges = 0
+        self._max_consecutive_fallback_nudges = 3
+        # Best-effort partial user transcription captured since the assistant last spoke,
+        # so a fallback nudge can forward whatever we have instead of claiming silence.
+        self._pending_final_transcripts: list[str] = []
+        self._latest_interim_transcript = ""
+
         # Interruption handling
         self._current_query_task: asyncio.Task | None = None
         self._interrupted = asyncio.Event()
@@ -121,18 +138,30 @@ class BenchmarkAgentProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
             return
 
+        # Capture in-progress transcription so a turn-end fallback can forward it.
+        if isinstance(frame, InterimTranscriptionFrame):
+            self._latest_interim_transcript = frame.text or ""
+
         # Check if frame type requires special processing
         if any(isinstance(frame, frame_type) for frame_type in WEBSOCKET_FRAME_TYPES):
             if isinstance(frame, TranscriptionFrame):
                 # Log transcription but don't process it
                 # Processing happens via on_user_turn_stopped event handler
                 logger.info(f"TranscriptionFrame (partial): {frame.text}")
+                # Buffer finalized segments so a fallback nudge can forward whatever the
+                # STT has produced so far; a finalized segment supersedes stale interim text.
+                if frame.text:
+                    self._pending_final_transcripts.append(frame.text)
+                    self._latest_interim_transcript = ""
                 # Frame will be aggregated by Pipecat's turn management
                 # and processed when on_user_turn_stopped fires
 
             elif isinstance(frame, UserStartedSpeakingFrame):
                 logger.info("User started speaking")
                 self._user_speaking = True
+                # NOTE: deliberately do NOT cancel the fallback timer here. VAD detecting
+                # speech does not mean the turn will ever complete; the fallback must still
+                # fire if VAD gets stuck. Only a fully completed turn cancels it.
 
             elif isinstance(frame, UserStoppedSpeakingFrame):
                 logger.info("User stopped speaking")
@@ -142,10 +171,14 @@ class BenchmarkAgentProcessor(FrameProcessor):
             elif isinstance(frame, BotStartedSpeakingFrame):
                 logger.info("Bot started speaking")
                 self._bot_speaking = True
+                # The assistant is talking; don't count this window toward the fallback.
+                self._cancel_fallback_timer()
 
             elif isinstance(frame, BotStoppedSpeakingFrame):
                 logger.info("Bot stopped speaking")
                 self._bot_speaking = False
+                # Assistant finished; start the clock waiting for the user to respond.
+                self._arm_fallback_timer()
 
             elif isinstance(frame, TurnTimestampFrame):
                 if frame.role == "assistant":
@@ -171,6 +204,35 @@ class BenchmarkAgentProcessor(FrameProcessor):
             self._current_query_task = None
         await super()._start_interruption()
 
+    def _arm_fallback_timer(self) -> None:
+        """Start a fresh turn-end fallback timer once the assistant stops speaking.
+
+        No-op when the fallback is disabled. Any previously armed timer is cancelled first
+        so only one window is ever pending.
+        """
+        if self._turn_end_fallback_time is None:
+            return
+        self._cancel_fallback_timer()
+        self._fallback_timer_task = asyncio.create_task(self._fallback_timer_loop())
+
+    def _cancel_fallback_timer(self) -> None:
+        """Cancel a pending turn-end fallback timer, if any."""
+        if self._fallback_timer_task and not self._fallback_timer_task.done():
+            self._fallback_timer_task.cancel()
+        self._fallback_timer_task = None
+
+    async def _fallback_timer_loop(self) -> None:
+        """Wait out the fallback window, then nudge the assistant to retry.
+
+        Cancelled (via ``_cancel_fallback_timer``) the instant the user starts speaking or
+        the assistant speaks again, so it only fires on genuine user silence.
+        """
+        try:
+            await asyncio.sleep(self._turn_end_fallback_time)
+        except asyncio.CancelledError:
+            return
+        await self.process_turn_fallback(self._turn_end_fallback_time)
+
     async def process_complete_user_turn(self, text: str) -> None:
         """Process a complete user turn from Pipecat's turn management.
 
@@ -183,6 +245,13 @@ class BenchmarkAgentProcessor(FrameProcessor):
         if not text or not text.strip():
             logger.debug("Ignoring empty user turn")
             return
+
+        # A real user turn landed: cancel any pending nudge, reset the give-up counter so
+        # each true turn gets a fresh allowance, and clear the partial-transcript buffer.
+        self._cancel_fallback_timer()
+        self._consecutive_fallback_nudges = 0
+        self._pending_final_transcripts.clear()
+        self._latest_interim_transcript = ""
 
         # Cancel any previous query still running
         if self._current_query_task and not self._current_query_task.done():
@@ -207,10 +276,86 @@ class BenchmarkAgentProcessor(FrameProcessor):
         finally:
             self._current_query_task = None
 
-    async def _process_user_query(self, text: str) -> None:
+    def _collect_partial_transcript(self) -> str:
+        """Assemble whatever the STT produced since the assistant last stopped speaking.
+
+        Combines finalized segments with the most recent (still un-finalized) interim text,
+        so a turn-end fallback can forward it instead of claiming no audio was received.
+        """
+        parts = [p for p in self._pending_final_transcripts if p]
+        if self._latest_interim_transcript:
+            parts.append(self._latest_interim_transcript)
+        return " ".join(parts).strip()
+
+    async def process_turn_fallback(self, timeout_seconds: int | None) -> None:
+        """Nudge the agent when turn-end detection times out without a completed user turn.
+
+        The fallback does not defer to VAD: it fires once the window elapses even if VAD
+        thinks the user is still speaking. Any partial transcription captured so far is
+        forwarded to the model (flagged as possibly incomplete) rather than claiming
+        silence. A marker is logged (flagged as a fallback turn) so metrics can skip/zero it.
+
+        Args:
+            timeout_seconds: The configured `EVA_TURN_END_FALLBACK_TIME` value.
+        """
+        # A query already running means a real turn is being processed; don't stack a nudge.
+        if self._current_query_task and not self._current_query_task.done():
+            logger.debug("Skipping turn-end fallback: a user query is already being processed")
+            return
+
+        # Give up after too many nudges in a row without the user coming back. Stop nudging
+        # and let the provider's inactivity backstop end the call (the pre-fallback behavior).
+        self._consecutive_fallback_nudges += 1
+        if self._consecutive_fallback_nudges > self._max_consecutive_fallback_nudges:
+            logger.warning(
+                f"Turn-end fallback exhausted after {self._max_consecutive_fallback_nudges} "
+                "consecutive nudges without a user turn; leaving the call to the inactivity backstop"
+            )
+            return
+
+        self._interrupted.clear()
+        partial = self._collect_partial_transcript()
+        # Consume the buffer so the next window starts fresh.
+        self._pending_final_transcripts.clear()
+        self._latest_interim_transcript = ""
+
+        if partial:
+            marker = (
+                f"turn-end not detected within {timeout_seconds}s; partial user speech: {partial!r}"
+            )
+            nudge = (
+                f"[Turn-end detection timed out after {timeout_seconds}s. The user may not have "
+                f"finished speaking and this transcription may be incomplete: {partial!r}. "
+                "If it is clear enough, respond to it; otherwise briefly ask the caller to finish "
+                "or repeat, continuing in the same language and tone as the conversation so far. "
+                "Do not mention this system note.]"
+            )
+        else:
+            marker = f"no user speech detected within {timeout_seconds}s"
+            nudge = (
+                f"[Turn-end detection timed out after {timeout_seconds}s with no user speech "
+                "captured. Briefly ask the caller to repeat what they said, continuing in the "
+                "same language and tone as the conversation so far. Do not mention this system note.]"
+            )
+
+        logger.info(
+            f"Turn-end fallback nudge "
+            f"({self._consecutive_fallback_nudges}/{self._max_consecutive_fallback_nudges}): {marker}"
+        )
+        self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
+
+        self._current_query_task = asyncio.create_task(self._process_user_query(nudge, log_user_input=False))
+        try:
+            await self._current_query_task
+        except asyncio.CancelledError:
+            logger.info("Turn-end fallback processing interrupted")
+        finally:
+            self._current_query_task = None
+
+    async def _process_user_query(self, text: str, log_user_input: bool = True) -> None:
         """Process a user query through the agentic system."""
         try:
-            async for response in self.agentic_system.process_query(text):
+            async for response in self.agentic_system.process_query(text, log_user_input=log_user_input):
                 if self._interrupted.is_set():
                     logger.info("Skipping response - interrupted")
                     return
@@ -280,6 +425,9 @@ class BenchmarkAgentProcessor(FrameProcessor):
     async def stop(self):
         """Stop the processor and cleanup."""
         logger.info("Stopping AgentProcessor...")
+
+        # Cancel any pending turn-end fallback timer
+        self._cancel_fallback_timer()
 
         # Cancel any in-progress query
         self._interrupted.set()

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -112,6 +112,9 @@ class BenchmarkAgentProcessor(FrameProcessor):
         # Turn-end fallback timer, owned and driven by UserObserver. Set there during pipeline
         # wiring; used here to cancel/reset on a real completed user turn.
         self.fallback_timer: TurnEndFallbackTimer | None = None
+        # Set by arm_fallback just before the backstop triggers a native turn-stop, so the
+        # resulting process_complete_user_turn frames this turn as a fallback. (timeout, partial)
+        self._pending_fallback: tuple[int | None, str] | None = None
 
         # Interruption handling
         self._current_query_task: asyncio.Task | None = None
@@ -185,22 +188,64 @@ class BenchmarkAgentProcessor(FrameProcessor):
             self.fallback_timer.cancel()
             self.fallback_timer.reset_counter()
 
+    def arm_fallback(self, timeout_seconds: int | None, partial: str) -> None:
+        """Mark the next turn-stop as a turn-end fallback (PROTOTYPE, cascade).
+
+        Called by UserObserver just before it fires a native turn-stop on the backstop timer, so
+        the resulting ``process_complete_user_turn`` frames the turn as a fallback (adjusted
+        prompt + turn_fallback marker for the penalty) rather than a real user turn.
+        """
+        self._pending_fallback = (timeout_seconds, partial)
+
+    def clear_pending_fallback(self) -> None:
+        """Discard an armed-but-unconsumed fallback so it can't leak into a later turn.
+
+        ``_pending_fallback`` is one-shot state for a single triggered turn-stop. If that native
+        turn-stop no-ops (Pipecat drops it when no user turn is open), the arm is never consumed
+        by ``process_complete_user_turn``. Called on a real turn start so the stale flag cannot
+        mis-frame a genuine user turn as a fallback.
+        """
+        self._pending_fallback = None
+
     async def process_complete_user_turn(self, text: str) -> None:
         """Process a complete user turn from Pipecat's turn management.
 
-        This is called by the on_user_turn_stopped event handler with the
-        complete user transcript.
+        This is called by the on_user_turn_stopped event handler with the complete user
+        transcript. When the turn-stop was triggered by the turn-end fallback backstop (see
+        ``arm_fallback``), the same standard path runs but the turn is framed as a fallback:
+        the model gets a "may be incomplete" nudge and a ``turn_fallback`` marker is recorded so
+        metrics penalize it. Riding this shared path is what gives the fallback native turn
+        boundaries without special post-processing.
 
         Args:
-            text: Complete user message from the turn
+            text: Complete user message from the turn (aggregated transcript).
         """
-        if not text or not text.strip():
-            logger.debug("Ignoring empty user turn")
-            return
+        fallback = self._pending_fallback
+        self._pending_fallback = None
+        text = (text or "").strip()
 
-        # A real user turn landed: cancel any pending nudge and reset the give-up counter so
-        # each true turn gets a fresh allowance.
-        self._reset_fallback_on_real_turn()
+        if fallback is None:
+            # Normal completed user turn.
+            if not text:
+                logger.debug("Ignoring empty user turn")
+                return
+            # A real user turn landed: cancel any pending nudge and reset the give-up counter so
+            # each true turn gets a fresh allowance.
+            self._reset_fallback_on_real_turn()
+            query_text = text
+            log_user_input = True
+        else:
+            # Turn-end fallback: the backstop decided the user's turn ended. Frame the (possibly
+            # empty/partial) transcript as a nudge and record a turn_fallback marker. Do NOT reset
+            # the give-up counter — this is a fallback and should count toward the cap.
+            timeout_seconds, buffered_partial = fallback
+            partial = text or buffered_partial
+            marker, query_text = build_fallback_nudge(timeout_seconds, partial)
+            log_user_input = False
+            if self.fallback_timer is not None:
+                self.fallback_timer.cancel()
+            self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=query_text)
+            logger.info(f"Processing turn-end fallback turn: {marker}")
 
         # Cancel any previous query still running
         if self._current_query_task and not self._current_query_task.done():
@@ -211,13 +256,15 @@ class BenchmarkAgentProcessor(FrameProcessor):
                 pass
 
         self._interrupted.clear()
-        logger.info(f"Processing complete user turn: {text}")
-
-        # Add to message aggregator for context
-        self._user_message_aggregator.append({"role": "user", "content": text})
+        if fallback is None:
+            logger.info(f"Processing complete user turn: {query_text}")
+            # Add to message aggregator for context
+            self._user_message_aggregator.append({"role": "user", "content": query_text})
 
         # Process through agentic system as a cancellable task
-        self._current_query_task = asyncio.create_task(self._process_user_query(text))
+        self._current_query_task = asyncio.create_task(
+            self._process_user_query(query_text, log_user_input=log_user_input)
+        )
         try:
             await self._current_query_task
         except asyncio.CancelledError:
@@ -229,31 +276,6 @@ class BenchmarkAgentProcessor(FrameProcessor):
     def query_in_flight(self) -> bool:
         """True while a real or nudge query is being processed (used by the fallback timer)."""
         return self._current_query_task is not None and not self._current_query_task.done()
-
-    async def process_turn_fallback(self, timeout_seconds: int | None, partial: str = "") -> None:
-        """Nudge the agent when turn-end detection times out without a completed user turn.
-
-        Called by ``UserObserver`` when the fallback timer fires (which owns the give-up
-        counter and query-in-flight guard). Any partial transcription captured so far is
-        forwarded to the model (flagged as possibly incomplete) rather than claiming silence.
-        A marker is logged (``message_type="turn_fallback"``) so metrics can skip/zero it.
-
-        Args:
-            timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
-            partial: Best-effort partial user transcription captured since the assistant last
-                spoke; empty string if none.
-        """
-        self._interrupted.clear()
-        marker, nudge = build_fallback_nudge(timeout_seconds, partial)
-        self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
-
-        self._current_query_task = asyncio.create_task(self._process_user_query(nudge, log_user_input=False))
-        try:
-            await self._current_query_task
-        except asyncio.CancelledError:
-            logger.info("Turn-end fallback processing interrupted")
-        finally:
-            self._current_query_task = None
 
     async def _process_user_query(self, text: str, log_user_input: bool = True) -> None:
         """Process a user query through the agentic system."""
@@ -388,6 +410,7 @@ class UserObserver(FrameProcessor):
         self,
         turn_end_fallback_time: int | None = None,
         fallback_processor=None,
+        turn_stop_strategy=None,
         **kwargs,
     ):
         """Initialize the user observer.
@@ -399,6 +422,11 @@ class UserObserver(FrameProcessor):
                 injects the nudge (cascade ``BenchmarkAgentProcessor`` or audio-LLM
                 ``AudioLLMProcessor``). It is given a back-reference to the timer so a real
                 completed user turn can cancel/reset it.
+            turn_stop_strategy: When provided (cascade), the fallback is the VAD's backup
+                turn-end decision: on fire it programmatically triggers this strategy's
+                ``trigger_user_turn_stopped()`` so the turn rides Pipecat's standard flow
+                (native ``on_user_turn_stopped`` → ``process_complete_user_turn`` → native
+                turn boundaries). When None (audio-LLM), the legacy bypass path is used.
             kwargs: args to be sent to the parent FrameProcessor
         """
         super().__init__(**kwargs)
@@ -410,6 +438,7 @@ class UserObserver(FrameProcessor):
         # completed turn. On fire, forwards any captured partial transcript to the processor.
         self._fallback = TurnEndFallbackTimer(turn_end_fallback_time, self._on_fallback_fire)
         self._fallback_processor = fallback_processor
+        self._turn_stop_strategy = turn_stop_strategy
         if fallback_processor is not None:
             fallback_processor.fallback_timer = self._fallback
 
@@ -453,6 +482,16 @@ class UserObserver(FrameProcessor):
             f"({self._fallback.consecutive_nudges}/{self._fallback.max_consecutive_nudges}): "
             f"{'partial: ' + partial if partial else 'no user speech'} within {timeout_seconds}s"
         )
+        if self._turn_stop_strategy is not None:
+            # PROTOTYPE (cascade): the fallback is the VAD's backup turn-end decision. Arm the
+            # processor with this turn's fallback context, then programmatically fire the native
+            # turn-stop so the turn rides Pipecat's standard flow (on_user_turn_stopped →
+            # process_complete_user_turn), producing native turn boundaries without the emulated
+            # boundary / rollback / metrics-preservation machinery the bypass path needs.
+            self._fallback_processor.arm_fallback(timeout_seconds, partial)
+            await self._turn_stop_strategy.trigger_user_turn_stopped()
+            return
+        # Legacy bypass path (audio-LLM): inject the nudge directly.
         await self._fallback_processor.process_turn_fallback(timeout_seconds, partial)
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> Awaitable[Frame]:
@@ -523,6 +562,10 @@ class UserObserver(FrameProcessor):
             # so cancelling here does not lose that case.
             self._user_speaking = True
             self._fallback.cancel()
+            # A real turn is starting: drop any fallback armed by a prior backstop whose native
+            # turn-stop no-op'd, so it can't mis-frame this genuine turn (cascade only).
+            if self._turn_stop_strategy is not None and self._fallback_processor is not None:
+                self._fallback_processor.clear_pending_fallback()
 
         elif isinstance(frame, UserStoppedSpeakingFrame):
             # Re-arm so a turn that never completes (e.g. empty transcript, and the bot never

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -22,6 +22,7 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from eva.assistant.agentic.audit_log import AuditLog
 from eva.assistant.agentic.system import AgenticSystem
+from eva.assistant.pipeline.fallback import TurnEndFallbackTimer, build_fallback_nudge
 from eva.assistant.pipeline.frames import (
     LLMMessageFrame,
     SpokenMessageFrame,
@@ -64,7 +65,6 @@ class BenchmarkAgentProcessor(FrameProcessor):
         output_dir=None,
         pre_tool_speech: str = "off",
         llm_streaming: bool = False,
-        turn_end_fallback_time: int | None = None,
         **kwargs,
     ) -> None:
         """Initialize the agent processor.
@@ -78,10 +78,10 @@ class BenchmarkAgentProcessor(FrameProcessor):
             output_dir: Optional output directory for saving performance stats
             pre_tool_speech: Lead-in mode ('off'|'auto')
             llm_streaming: Stream LLM output sentence-by-sentence
-            turn_end_fallback_time: Seconds of silence after the assistant stops speaking
-                before nudging it to retry (VAD-driven). ``None`` disables the fallback and
-                preserves the old behavior of waiting for the provider's inactivity timeout.
             **kwargs: Additional keyword arguments passed to FrameProcessor
+
+        The turn-end fallback timer is hosted by ``UserObserver`` (on the pipeline spine), which
+        calls this processor's ``process_turn_fallback`` when it fires; see ``fallback.py``.
         """
         super().__init__(**kwargs)
 
@@ -109,18 +109,9 @@ class BenchmarkAgentProcessor(FrameProcessor):
         self._user_speaking = False
         self._bot_speaking = False
 
-        # Turn-end fallback: a fresh timer is armed each time the assistant stops speaking
-        # and fires `turn_end_fallback_time` seconds later REGARDLESS of what VAD reports.
-        # The fallback exists precisely for when VAD is wrong (e.g. it never closes the
-        # user's turn), so it deliberately does not defer to VAD speech-start signals.
-        self._turn_end_fallback_time = turn_end_fallback_time
-        self._fallback_timer_task: asyncio.Task | None = None
-        self._consecutive_fallback_nudges = 0
-        self._max_consecutive_fallback_nudges = 3
-        # Best-effort partial user transcription captured since the assistant last spoke,
-        # so a fallback nudge can forward whatever we have instead of claiming silence.
-        self._pending_final_transcripts: list[str] = []
-        self._latest_interim_transcript = ""
+        # Turn-end fallback timer, owned and driven by UserObserver. Set there during pipeline
+        # wiring; used here to cancel/reset on a real completed user turn.
+        self.fallback_timer: TurnEndFallbackTimer | None = None
 
         # Interruption handling
         self._current_query_task: asyncio.Task | None = None
@@ -138,30 +129,18 @@ class BenchmarkAgentProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
             return
 
-        # Capture in-progress transcription so a turn-end fallback can forward it.
-        if isinstance(frame, InterimTranscriptionFrame):
-            self._latest_interim_transcript = frame.text or ""
-
         # Check if frame type requires special processing
         if any(isinstance(frame, frame_type) for frame_type in WEBSOCKET_FRAME_TYPES):
             if isinstance(frame, TranscriptionFrame):
                 # Log transcription but don't process it
                 # Processing happens via on_user_turn_stopped event handler
                 logger.info(f"TranscriptionFrame (partial): {frame.text}")
-                # Buffer finalized segments so a fallback nudge can forward whatever the
-                # STT has produced so far; a finalized segment supersedes stale interim text.
-                if frame.text:
-                    self._pending_final_transcripts.append(frame.text)
-                    self._latest_interim_transcript = ""
                 # Frame will be aggregated by Pipecat's turn management
                 # and processed when on_user_turn_stopped fires
 
             elif isinstance(frame, UserStartedSpeakingFrame):
                 logger.info("User started speaking")
                 self._user_speaking = True
-                # NOTE: deliberately do NOT cancel the fallback timer here. VAD detecting
-                # speech does not mean the turn will ever complete; the fallback must still
-                # fire if VAD gets stuck. Only a fully completed turn cancels it.
 
             elif isinstance(frame, UserStoppedSpeakingFrame):
                 logger.info("User stopped speaking")
@@ -171,14 +150,10 @@ class BenchmarkAgentProcessor(FrameProcessor):
             elif isinstance(frame, BotStartedSpeakingFrame):
                 logger.info("Bot started speaking")
                 self._bot_speaking = True
-                # The assistant is talking; don't count this window toward the fallback.
-                self._cancel_fallback_timer()
 
             elif isinstance(frame, BotStoppedSpeakingFrame):
                 logger.info("Bot stopped speaking")
                 self._bot_speaking = False
-                # Assistant finished; start the clock waiting for the user to respond.
-                self._arm_fallback_timer()
 
             elif isinstance(frame, TurnTimestampFrame):
                 if frame.role == "assistant":
@@ -204,34 +179,11 @@ class BenchmarkAgentProcessor(FrameProcessor):
             self._current_query_task = None
         await super()._start_interruption()
 
-    def _arm_fallback_timer(self) -> None:
-        """Start a fresh turn-end fallback timer once the assistant stops speaking.
-
-        No-op when the fallback is disabled. Any previously armed timer is cancelled first
-        so only one window is ever pending.
-        """
-        if self._turn_end_fallback_time is None:
-            return
-        self._cancel_fallback_timer()
-        self._fallback_timer_task = asyncio.create_task(self._fallback_timer_loop())
-
-    def _cancel_fallback_timer(self) -> None:
-        """Cancel a pending turn-end fallback timer, if any."""
-        if self._fallback_timer_task and not self._fallback_timer_task.done():
-            self._fallback_timer_task.cancel()
-        self._fallback_timer_task = None
-
-    async def _fallback_timer_loop(self) -> None:
-        """Wait out the fallback window, then nudge the assistant to retry.
-
-        Cancelled (via ``_cancel_fallback_timer``) the instant the user starts speaking or
-        the assistant speaks again, so it only fires on genuine user silence.
-        """
-        try:
-            await asyncio.sleep(self._turn_end_fallback_time)
-        except asyncio.CancelledError:
-            return
-        await self.process_turn_fallback(self._turn_end_fallback_time)
+    def _reset_fallback_on_real_turn(self) -> None:
+        """A real user turn landed: cancel any pending nudge and reset the give-up counter."""
+        if self.fallback_timer is not None:
+            self.fallback_timer.cancel()
+            self.fallback_timer.reset_counter()
 
     async def process_complete_user_turn(self, text: str) -> None:
         """Process a complete user turn from Pipecat's turn management.
@@ -246,12 +198,9 @@ class BenchmarkAgentProcessor(FrameProcessor):
             logger.debug("Ignoring empty user turn")
             return
 
-        # A real user turn landed: cancel any pending nudge, reset the give-up counter so
-        # each true turn gets a fresh allowance, and clear the partial-transcript buffer.
-        self._cancel_fallback_timer()
-        self._consecutive_fallback_nudges = 0
-        self._pending_final_transcripts.clear()
-        self._latest_interim_transcript = ""
+        # A real user turn landed: cancel any pending nudge and reset the give-up counter so
+        # each true turn gets a fresh allowance.
+        self._reset_fallback_on_real_turn()
 
         # Cancel any previous query still running
         if self._current_query_task and not self._current_query_task.done():
@@ -276,72 +225,26 @@ class BenchmarkAgentProcessor(FrameProcessor):
         finally:
             self._current_query_task = None
 
-    def _collect_partial_transcript(self) -> str:
-        """Assemble whatever the STT produced since the assistant last stopped speaking.
+    @property
+    def query_in_flight(self) -> bool:
+        """True while a real or nudge query is being processed (used by the fallback timer)."""
+        return self._current_query_task is not None and not self._current_query_task.done()
 
-        Combines finalized segments with the most recent (still un-finalized) interim text,
-        so a turn-end fallback can forward it instead of claiming no audio was received.
-        """
-        parts = [p for p in self._pending_final_transcripts if p]
-        if self._latest_interim_transcript:
-            parts.append(self._latest_interim_transcript)
-        return " ".join(parts).strip()
-
-    async def process_turn_fallback(self, timeout_seconds: int | None) -> None:
+    async def process_turn_fallback(self, timeout_seconds: int | None, partial: str = "") -> None:
         """Nudge the agent when turn-end detection times out without a completed user turn.
 
-        The fallback does not defer to VAD: it fires once the window elapses even if VAD
-        thinks the user is still speaking. Any partial transcription captured so far is
-        forwarded to the model (flagged as possibly incomplete) rather than claiming
-        silence. A marker is logged (flagged as a fallback turn) so metrics can skip/zero it.
+        Called by ``UserObserver`` when the fallback timer fires (which owns the give-up
+        counter and query-in-flight guard). Any partial transcription captured so far is
+        forwarded to the model (flagged as possibly incomplete) rather than claiming silence.
+        A marker is logged (``message_type="turn_fallback"``) so metrics can skip/zero it.
 
         Args:
-            timeout_seconds: The configured `EVA_TURN_END_FALLBACK_TIME` value.
+            timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
+            partial: Best-effort partial user transcription captured since the assistant last
+                spoke; empty string if none.
         """
-        # A query already running means a real turn is being processed; don't stack a nudge.
-        if self._current_query_task and not self._current_query_task.done():
-            logger.debug("Skipping turn-end fallback: a user query is already being processed")
-            return
-
-        # Give up after too many nudges in a row without the user coming back. Stop nudging
-        # and let the provider's inactivity backstop end the call (the pre-fallback behavior).
-        self._consecutive_fallback_nudges += 1
-        if self._consecutive_fallback_nudges > self._max_consecutive_fallback_nudges:
-            logger.warning(
-                f"Turn-end fallback exhausted after {self._max_consecutive_fallback_nudges} "
-                "consecutive nudges without a user turn; leaving the call to the inactivity backstop"
-            )
-            return
-
         self._interrupted.clear()
-        partial = self._collect_partial_transcript()
-        # Consume the buffer so the next window starts fresh.
-        self._pending_final_transcripts.clear()
-        self._latest_interim_transcript = ""
-
-        if partial:
-            marker = (
-                f"turn-end not detected within {timeout_seconds}s; partial user speech: {partial!r}"
-            )
-            nudge = (
-                f"[Turn-end detection timed out after {timeout_seconds}s. The user may not have "
-                f"finished speaking and this transcription may be incomplete: {partial!r}. "
-                "If it is clear enough, respond to it; otherwise briefly ask the caller to finish "
-                "or repeat, continuing in the same language and tone as the conversation so far. "
-                "Do not mention this system note.]"
-            )
-        else:
-            marker = f"no user speech detected within {timeout_seconds}s"
-            nudge = (
-                f"[Turn-end detection timed out after {timeout_seconds}s with no user speech "
-                "captured. Briefly ask the caller to repeat what they said, continuing in the "
-                "same language and tone as the conversation so far. Do not mention this system note.]"
-            )
-
-        logger.info(
-            f"Turn-end fallback nudge "
-            f"({self._consecutive_fallback_nudges}/{self._max_consecutive_fallback_nudges}): {marker}"
-        )
+        marker, nudge = build_fallback_nudge(timeout_seconds, partial)
         self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
 
         self._current_query_task = asyncio.create_task(self._process_user_query(nudge, log_user_input=False))
@@ -426,8 +329,9 @@ class BenchmarkAgentProcessor(FrameProcessor):
         """Stop the processor and cleanup."""
         logger.info("Stopping AgentProcessor...")
 
-        # Cancel any pending turn-end fallback timer
-        self._cancel_fallback_timer()
+        # Cancel any pending turn-end fallback timer (owned by UserObserver)
+        if self.fallback_timer is not None:
+            self.fallback_timer.cancel()
 
         # Cancel any in-progress query
         self._interrupted.set()
@@ -469,27 +373,94 @@ class BenchmarkAgentProcessor(FrameProcessor):
 
 
 class UserObserver(FrameProcessor):
-    """Observes STT transcription frames and VAD events to track latency metrics and emit user messages."""
+    """Observes STT/VAD frames on the pipeline spine to track latency metrics and host the turn-end fallback timer.
 
-    def __init__(self, **kwargs):
-        """Initialize the user observer."""
+    Sits before ``user_aggregator`` (which consumes turn frames) in every pipeline flavor, so
+    it sees both the user turn frames and the TTS-originated ``Bot*SpeakingFrame`` frames that
+    flow upstream. That makes it the natural home for the turn-end fallback timer, which must
+    arm/cancel on those frames and works identically for the cascade and audio-LLM pipelines.
+    The nudge itself is injected by the pipeline-specific ``fallback_processor`` (which owns the
+    model/query machinery); this observer only owns the timer, the give-up counter, and the
+    best-effort partial-transcript buffer.
+    """
+
+    def __init__(
+        self,
+        turn_end_fallback_time: int | None = None,
+        fallback_processor=None,
+        **kwargs,
+    ):
+        """Initialize the user observer.
+
+        Args:
+            turn_end_fallback_time: Seconds of undetected user silence after the assistant
+                stops speaking before nudging it to reprompt. ``None`` disables the fallback.
+            fallback_processor: The pipeline-specific processor whose ``process_turn_fallback``
+                injects the nudge (cascade ``BenchmarkAgentProcessor`` or audio-LLM
+                ``AudioLLMProcessor``). It is given a back-reference to the timer so a real
+                completed user turn can cancel/reset it.
+            kwargs: args to be sent to the parent FrameProcessor
+        """
         super().__init__(**kwargs)
         self._last_transcription_time: float | None = None
         self._user_context = []
 
+        # Turn-end fallback timer. Armed when the assistant stops speaking; cancelled when the
+        # assistant or the user starts speaking; re-armed when the user stops speaking without a
+        # completed turn. On fire, forwards any captured partial transcript to the processor.
+        self._fallback = TurnEndFallbackTimer(turn_end_fallback_time, self._on_fallback_fire)
+        self._fallback_processor = fallback_processor
+        if fallback_processor is not None:
+            fallback_processor.fallback_timer = self._fallback
+
+        # Best-effort partial user transcription captured since the assistant last spoke, so a
+        # fallback nudge can forward whatever we have instead of claiming silence. Only populated
+        # in the cascade pipeline (audio-LLM has no STT transcript on the spine).
+        self._pending_final_transcripts: list[str] = []
+        self._latest_interim_transcript = ""
+
+    def _collect_partial_transcript(self) -> str:
+        """Assemble whatever the STT produced since the assistant last stopped speaking."""
+        parts = [p for p in self._pending_final_transcripts if p]
+        if self._latest_interim_transcript:
+            parts.append(self._latest_interim_transcript)
+        return " ".join(parts).strip()
+
+    async def _on_fallback_fire(self, timeout_seconds: int | None) -> None:
+        """Timer callback: nudge the assistant to reprompt on undetected user silence."""
+        if self._fallback_processor is None:
+            return
+        # A query already running means a real turn is being processed; don't stack a nudge.
+        if self._fallback_processor.query_in_flight:
+            logger.debug("Skipping turn-end fallback: a user query is already being processed")
+            return
+        if not self._fallback.note_nudge():
+            return
+        partial = self._collect_partial_transcript()
+        self._pending_final_transcripts.clear()
+        self._latest_interim_transcript = ""
+        logger.info(
+            f"Turn-end fallback nudge "
+            f"({self._fallback.consecutive_nudges}/{self._fallback.max_consecutive_nudges}): "
+            f"{'partial: ' + partial if partial else 'no user speech'} within {timeout_seconds}s"
+        )
+        await self._fallback_processor.process_turn_fallback(timeout_seconds, partial)
+
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> Awaitable[Frame]:
-        """Process frames to track transcription timing and VAD events.
+        """Process frames to track transcription timing, VAD events, and the fallback timer.
 
         - Tracks the timing between STT responses and VAD firing to calculate the "VAD buffer" -
           how much latency exists between the last transcription chunk and when speech detection ends.
         - Emits UserMessageFrame for each TranscriptionFrame to allow other processors to observe
           user transcriptions without interfering with the context aggregator.
+        - Arms/cancels the turn-end fallback timer on bot/user speaking frames.
         """
         await super().process_frame(frame, direction)
 
         if isinstance(frame, InterimTranscriptionFrame):
             # Log interim transcription frames for debugging
             logger.debug(f"Interim transcription received: '{frame.text}'")
+            self._latest_interim_transcript = frame.text or ""
 
         elif isinstance(frame, TranscriptionFrame):
             transcription_text = frame.text.strip()
@@ -497,6 +468,11 @@ class UserObserver(FrameProcessor):
                 # Track final transcription time for VAD buffer calculation
                 self._last_transcription_time = time.time()
                 self._user_context.append({"role": "user", "content": transcription_text})
+
+                # Buffer finalized segments so a fallback nudge can forward whatever the STT
+                # has produced so far; a finalized segment supersedes stale interim text.
+                self._pending_final_transcripts.append(transcription_text)
+                self._latest_interim_transcript = ""
 
                 # Log partial transcription (buffered by user_aggregator, not processed immediately)
                 logger.info(f"TranscriptionFrame (buffered): '{transcription_text}'")
@@ -508,7 +484,29 @@ class UserObserver(FrameProcessor):
                 # NOTE: Do NOT push UserContextFrame here - it triggers immediate LLM processing!
                 # The on_user_turn_stopped event handler will process the complete turn.
 
+        elif isinstance(frame, BotStartedSpeakingFrame):
+            # The assistant is talking; this window does not count toward the fallback.
+            self._fallback.cancel()
+
+        elif isinstance(frame, BotStoppedSpeakingFrame):
+            # Assistant finished; start the clock waiting for the user to respond.
+            self._fallback.arm()
+
+        elif isinstance(frame, UserStartedSpeakingFrame):
+            # The user is speaking: cancel the fallback so it never fires mid-turn. Pipecat's
+            # own user_turn_stop_timeout watchdog still finalizes a genuinely stuck-open turn,
+            # so cancelling here does not lose that case.
+            self._fallback.cancel()
+
         elif isinstance(frame, UserStoppedSpeakingFrame):
+            # Re-arm so a turn that never completes (e.g. empty transcript, and the bot never
+            # speaks again) still eventually nudges. A real completed turn cancels/resets the
+            # timer via the processor's process_complete_user_turn (fired separately through the
+            # on_user_turn_stopped event handler); the query_in_flight guard there prevents this
+            # re-arm from racing it into a spurious nudge.
+            if self._fallback_processor is None or not self._fallback_processor.query_in_flight:
+                self._fallback.arm()
+
             # Track VAD events (when user stops speaking)
             if self._last_transcription_time is not None:
                 current_time = time.time()
@@ -524,8 +522,6 @@ class UserObserver(FrameProcessor):
 
                 # Reset for next turn
                 self._last_transcription_time = None
-            else:
-                logger.warning("VAD fired but no previous transcription timestamp found")
 
         await self.push_frame(frame, direction)
 

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -419,6 +419,12 @@ class UserObserver(FrameProcessor):
         self._pending_final_transcripts: list[str] = []
         self._latest_interim_transcript = ""
 
+        # True between UserStartedSpeakingFrame and UserStoppedSpeakingFrame. The audio-LLM
+        # pipeline has no STT on the spine, so a trailing BotStoppedSpeakingFrame (from the
+        # assistant's own TTS audio still draining) is otherwise indistinguishable from real
+        # silence and can re-arm the timer while the user is already mid-turn.
+        self._user_speaking = False
+
     def _collect_partial_transcript(self) -> str:
         """Assemble whatever the STT produced since the assistant last stopped speaking."""
         parts = [p for p in self._pending_final_transcripts if p]
@@ -433,6 +439,9 @@ class UserObserver(FrameProcessor):
         # A query already running means a real turn is being processed; don't stack a nudge.
         if self._fallback_processor.query_in_flight:
             logger.debug("Skipping turn-end fallback: a user query is already being processed")
+            return
+        if self._user_speaking:
+            logger.debug("Skipping turn-end fallback: the user is currently speaking")
             return
         if not self._fallback.note_nudge():
             return
@@ -461,6 +470,12 @@ class UserObserver(FrameProcessor):
             # Log interim transcription frames for debugging
             logger.debug(f"Interim transcription received: '{frame.text}'")
             self._latest_interim_transcript = frame.text or ""
+            # An interim is live evidence the user is still speaking. On the eager-EOT STT
+            # path, UserStartedSpeaking may not fire (or a draining BotStoppedSpeaking re-arms
+            # the timer mid-utterance), so without this the nudge fires while the user talks.
+            # Re-arm rather than only cancel so the 2s window measures silence-since-last-
+            # activity: the nudge still fires 2s after the user actually goes quiet.
+            self._fallback.arm()
 
         elif isinstance(frame, TranscriptionFrame):
             transcription_text = frame.text.strip()
@@ -489,13 +504,24 @@ class UserObserver(FrameProcessor):
             self._fallback.cancel()
 
         elif isinstance(frame, BotStoppedSpeakingFrame):
-            # Assistant finished; start the clock waiting for the user to respond.
-            self._fallback.arm()
+            # The transport fires this after ~350ms of silence in the outgoing audio, which
+            # also happens *between* TTS chunks within a single multi-sentence response (the
+            # agent pushes one speak frame per sentence). Only start the clock if the query
+            # that's driving those chunks has actually finished; otherwise more speech is
+            # still coming and arming here just races the assistant's own output. Also skip
+            # if the user is already mid-turn: a trailing BotStoppedSpeakingFrame from the
+            # assistant's own draining TTS audio can land after UserStartedSpeakingFrame and
+            # would otherwise re-arm the timer against a turn that's already in progress.
+            if not self._user_speaking and (
+                self._fallback_processor is None or not self._fallback_processor.query_in_flight
+            ):
+                self._fallback.arm()
 
         elif isinstance(frame, UserStartedSpeakingFrame):
             # The user is speaking: cancel the fallback so it never fires mid-turn. Pipecat's
             # own user_turn_stop_timeout watchdog still finalizes a genuinely stuck-open turn,
             # so cancelling here does not lose that case.
+            self._user_speaking = True
             self._fallback.cancel()
 
         elif isinstance(frame, UserStoppedSpeakingFrame):
@@ -504,6 +530,7 @@ class UserObserver(FrameProcessor):
             # timer via the processor's process_complete_user_turn (fired separately through the
             # on_user_turn_stopped event handler); the query_in_flight guard there prevents this
             # re-arm from racing it into a spurious nudge.
+            self._user_speaking = False
             if self._fallback_processor is None or not self._fallback_processor.query_in_flight:
                 self._fallback.arm()
 

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -232,6 +232,10 @@ class BenchmarkAgentProcessor(FrameProcessor):
             # A real user turn landed: cancel any pending nudge and reset the give-up counter so
             # each true turn gets a fresh allowance.
             self._reset_fallback_on_real_turn()
+            # Clear the pending transcripts so the next fallback only includes transcriptions
+            # since the assistant responds to this turn.
+            self._pending_final_transcripts.clear()
+            self._latest_interim_transcript = ""
             query_text = text
             log_user_input = True
         else:
@@ -393,6 +397,56 @@ class BenchmarkAgentProcessor(FrameProcessor):
             finally:
                 self._aggregator_flush_task = None
 
+    async def process_turn_fallback(
+        self, timeout_seconds: int | None, partial: str = "", turn_stop_strategy=None
+    ) -> None:
+        """Fallback path when native turn-stop is a no-op (no open user turn in Pipecat).
+
+        This is called when the cascade's ``trigger_user_turn_stopped()`` fails to close a turn
+        because there's no open turn in Pipecat's turn management. This can happen when:
+        - A VAD fragment arrives after the previous turn has already completed and been processed
+        - The fragment is not long enough to trigger a new turn in Pipecat's aggregator
+        - The fallback timer fires, but the turn-stop is silently dropped
+
+        For the cascade path, this method first tries the native turn-stop (via arm_fallback +
+        trigger_user_turn_stopped), and if that's available. If it fails or times out, it falls
+        back to directly processing the nudge as a synthetic turn.
+
+        Args:
+            timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
+            partial: Best-effort partial transcript from the incomplete turn.
+            turn_stop_strategy: When provided (cascade), try the native turn-stop first.
+        """
+        # For cascade: try the native turn-stop path first. If it succeeds, we're done.
+        if turn_stop_strategy is not None:
+            self.arm_fallback(timeout_seconds, partial)
+            await turn_stop_strategy.trigger_user_turn_stopped()
+            # Give Pipecat's turn management a brief window to process. If _pending_fallback
+            # is still set after this, the turn-stop was a no-op and we'll fall through to
+            # the direct processing path below.
+            await asyncio.sleep(0.1)
+            if self._pending_fallback is None:
+                # Turn-stop succeeded and was processed
+                logger.debug("Native turn-stop for fallback succeeded")
+                return
+            # Turn-stop was a no-op: fall through to direct processing
+            logger.debug("Native turn-stop for fallback was a no-op; using direct processing")
+            self.clear_pending_fallback()
+
+        # Direct fallback path: process the nudge immediately without waiting for turn-stop.
+        marker, nudge = build_fallback_nudge(timeout_seconds, partial, has_audio=False)
+        logger.info(f"Processing fallback (direct): {marker[:60]}...")
+        self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
+        try:
+            async for response in self.agentic_system.process_query(nudge, log_user_input=False):
+                if response:
+                    await self._handle_response(response)
+        except asyncio.CancelledError:
+            logger.debug("Fallback query cancelled during pipeline shutdown")
+            raise
+        except Exception as e:
+            logger.error(f"Error processing fallback query: {e}", exc_info=True)
+
 
 class UserObserver(FrameProcessor):
     """Observes STT/VAD frames on the pipeline spine to track latency metrics and host the turn-end fallback timer.
@@ -498,21 +552,15 @@ class UserObserver(FrameProcessor):
             f"({self._fallback.consecutive_nudges}/{self._fallback.max_consecutive_nudges}): "
             f"{'partial: ' + partial if partial else 'no user speech'} within {timeout_seconds}s"
         )
-        if self._turn_stop_strategy is not None:
-            # PROTOTYPE (cascade): the fallback is the VAD's backup turn-end decision. Arm the
-            # processor with this turn's fallback context, then programmatically fire the native
-            # turn-stop so the turn rides Pipecat's standard flow (on_user_turn_stopped →
-            # process_complete_user_turn), producing native turn boundaries without the emulated
-            # boundary / rollback / metrics-preservation machinery the bypass path needs.
-            self._fallback_processor.arm_fallback(timeout_seconds, partial)
-            await self._turn_stop_strategy.trigger_user_turn_stopped()
-            # Shutdown can land during the await above. Drop the arm if it was never
-            # consumed, so it can't mis-frame a transcript flushed during teardown.
-            if self._fallback.shutting_down:
-                self._fallback_processor.clear_pending_fallback()
-            return
-        # Legacy bypass path (audio-LLM): inject the nudge directly.
-        await self._fallback_processor.process_turn_fallback(timeout_seconds, partial)
+        # Process the fallback nudge. For cascade, this will try the native turn-stop first
+        # and fall back to direct processing if that's a no-op. For audio-LLM, it goes
+        # straight to direct processing.
+        await self._fallback_processor.process_turn_fallback(
+            timeout_seconds, partial, turn_stop_strategy=self._turn_stop_strategy
+        )
+        # Shutdown can land during processing. Drop any pending fallback that wasn't consumed.
+        if self._fallback.shutting_down and self._fallback_processor is not None:
+            self._fallback_processor.clear_pending_fallback()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> Awaitable[Frame]:
         """Process frames to track transcription timing, VAD events, and the fallback timer.

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -461,9 +461,25 @@ class UserObserver(FrameProcessor):
             parts.append(self._latest_interim_transcript)
         return " ".join(parts).strip()
 
+    def shutdown_fallback(self) -> None:
+        """Latch the fallback off for good: the call is ending.
+
+        Also discards any fallback armed on the cascade processor. On that path
+        ``_on_fallback_fire`` sets ``_pending_fallback`` and then *awaits* a native turn-stop,
+        so a shutdown landing in between would otherwise leave the flag set — and a
+        transcript flushed during teardown would be mis-framed as a fallback turn.
+        """
+        self._fallback.shutdown()
+        if self._fallback_processor is not None and self._turn_stop_strategy is not None:
+            self._fallback_processor.clear_pending_fallback()
+
     async def _on_fallback_fire(self, timeout_seconds: int | None) -> None:
         """Timer callback: nudge the assistant to reprompt on undetected user silence."""
         if self._fallback_processor is None:
+            return
+        # The call is ending; remaining silence is terminal, not a dropped user turn.
+        if self._fallback.shutting_down:
+            logger.debug("Skipping turn-end fallback: the conversation is ending")
             return
         # A query already running means a real turn is being processed; don't stack a nudge.
         if self._fallback_processor.query_in_flight:
@@ -490,6 +506,10 @@ class UserObserver(FrameProcessor):
             # boundary / rollback / metrics-preservation machinery the bypass path needs.
             self._fallback_processor.arm_fallback(timeout_seconds, partial)
             await self._turn_stop_strategy.trigger_user_turn_stopped()
+            # Shutdown can land during the await above. Drop the arm if it was never
+            # consumed, so it can't mis-frame a transcript flushed during teardown.
+            if self._fallback.shutting_down:
+                self._fallback_processor.clear_pending_fallback()
             return
         # Legacy bypass path (audio-LLM): inject the nudge directly.
         await self._fallback_processor.process_turn_fallback(timeout_seconds, partial)
@@ -502,10 +522,17 @@ class UserObserver(FrameProcessor):
         - Emits UserMessageFrame for each TranscriptionFrame to allow other processors to observe
           user transcriptions without interfering with the context aggregator.
         - Arms/cancels the turn-end fallback timer on bot/user speaking frames.
+        - Latches the fallback off on End/Cancel so teardown silence can't trigger a nudge.
         """
         await super().process_frame(frame, direction)
 
-        if isinstance(frame, InterimTranscriptionFrame):
+        if isinstance(frame, (EndFrame, CancelFrame)):
+            # The call is over: latch the fallback off. Without this the timer armed by the
+            # assistant's last BotStoppedSpeakingFrame survives teardown and fires into a
+            # closed conversation, producing a phantom turn that scores 0.
+            self.shutdown_fallback()
+
+        elif isinstance(frame, InterimTranscriptionFrame):
             # Log interim transcription frames for debugging
             logger.debug(f"Interim transcription received: '{frame.text}'")
             self._latest_interim_transcript = frame.text or ""

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -443,6 +443,8 @@ class BenchmarkAgentProcessor(FrameProcessor):
         marker, nudge = build_fallback_nudge(timeout_seconds, partial, has_audio=False)
         logger.info(f"Processing fallback (direct): {marker[:60]}...")
         self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
+        # Clear any prior interruption so the fallback response can be spoken.
+        self._interrupted.clear()
         try:
             async for response in self.agentic_system.process_query(nudge, log_user_input=False):
                 if response:

--- a/src/eva/assistant/pipeline/agent_processor.py
+++ b/src/eva/assistant/pipeline/agent_processor.py
@@ -116,6 +116,12 @@ class BenchmarkAgentProcessor(FrameProcessor):
         # resulting process_complete_user_turn frames this turn as a fallback. (timeout, partial)
         self._pending_fallback: tuple[int | None, str] | None = None
 
+        # Best-effort partial user transcription captured since the assistant last spoke, so a
+        # fallback nudge can forward whatever we have instead of claiming silence. Only populated
+        # in the cascade pipeline (audio-LLM has no STT transcript on the spine).
+        self._pending_final_transcripts: list[str] = []
+        self._latest_interim_transcript = ""
+
         # Interruption handling
         self._current_query_task: asyncio.Task | None = None
         self._interrupted = asyncio.Event()
@@ -496,12 +502,6 @@ class UserObserver(FrameProcessor):
         if fallback_processor is not None:
             fallback_processor.fallback_timer = self._fallback
 
-        # Best-effort partial user transcription captured since the assistant last spoke, so a
-        # fallback nudge can forward whatever we have instead of claiming silence. Only populated
-        # in the cascade pipeline (audio-LLM has no STT transcript on the spine).
-        self._pending_final_transcripts: list[str] = []
-        self._latest_interim_transcript = ""
-
         # True between UserStartedSpeakingFrame and UserStoppedSpeakingFrame. The audio-LLM
         # pipeline has no STT on the spine, so a trailing BotStoppedSpeakingFrame (from the
         # assistant's own TTS audio still draining) is otherwise indistinguishable from real
@@ -510,9 +510,11 @@ class UserObserver(FrameProcessor):
 
     def _collect_partial_transcript(self) -> str:
         """Assemble whatever the STT produced since the assistant last stopped speaking."""
-        parts = [p for p in self._pending_final_transcripts if p]
-        if self._latest_interim_transcript:
-            parts.append(self._latest_interim_transcript)
+        if self._fallback_processor is None:
+            return ""
+        parts = [p for p in self._fallback_processor._pending_final_transcripts if p]
+        if self._fallback_processor._latest_interim_transcript:
+            parts.append(self._fallback_processor._latest_interim_transcript)
         return " ".join(parts).strip()
 
     def shutdown_fallback(self) -> None:
@@ -545,8 +547,9 @@ class UserObserver(FrameProcessor):
         if not self._fallback.note_nudge():
             return
         partial = self._collect_partial_transcript()
-        self._pending_final_transcripts.clear()
-        self._latest_interim_transcript = ""
+        if self._fallback_processor is not None:
+            self._fallback_processor._pending_final_transcripts.clear()
+            self._fallback_processor._latest_interim_transcript = ""
         logger.info(
             f"Turn-end fallback nudge "
             f"({self._fallback.consecutive_nudges}/{self._fallback.max_consecutive_nudges}): "
@@ -583,7 +586,8 @@ class UserObserver(FrameProcessor):
         elif isinstance(frame, InterimTranscriptionFrame):
             # Log interim transcription frames for debugging
             logger.debug(f"Interim transcription received: '{frame.text}'")
-            self._latest_interim_transcript = frame.text or ""
+            if self._fallback_processor is not None:
+                self._fallback_processor._latest_interim_transcript = frame.text or ""
             # An interim is live evidence the user is still speaking. On the eager-EOT STT
             # path, UserStartedSpeaking may not fire (or a draining BotStoppedSpeaking re-arms
             # the timer mid-utterance), so without this the nudge fires while the user talks.
@@ -600,8 +604,9 @@ class UserObserver(FrameProcessor):
 
                 # Buffer finalized segments so a fallback nudge can forward whatever the STT
                 # has produced so far; a finalized segment supersedes stale interim text.
-                self._pending_final_transcripts.append(transcription_text)
-                self._latest_interim_transcript = ""
+                if self._fallback_processor is not None:
+                    self._fallback_processor._pending_final_transcripts.append(transcription_text)
+                    self._fallback_processor._latest_interim_transcript = ""
 
                 # Log partial transcription (buffered by user_aggregator, not processed immediately)
                 logger.info(f"TranscriptionFrame (buffered): '{transcription_text}'")

--- a/src/eva/assistant/pipeline/audio_llm_processor.py
+++ b/src/eva/assistant/pipeline/audio_llm_processor.py
@@ -379,8 +379,11 @@ class AudioLLMProcessor(FrameProcessor):
             source_sample_rate = self.audio_collector.frame_sample_rate
             self._current_query_task = asyncio.create_task(self._process_audio_turn(audio_bytes, source_sample_rate))
         else:
-            # No audio captured at all — reprompt via text.
+            # No audio captured at all (genuine silence) — reprompt via text. Record a no-audio
+            # turn so _turn_audio_history stays aligned 1:1 with user messages (full_audio_context
+            # relies on that alignment); this turn is left as its text reprompt in the prompt.
             self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
+            self.agentic_system.note_non_audio_turn()
             self._current_query_task = asyncio.create_task(self._process_text_query(nudge))
         try:
             await self._current_query_task

--- a/src/eva/assistant/pipeline/audio_llm_processor.py
+++ b/src/eva/assistant/pipeline/audio_llm_processor.py
@@ -39,6 +39,7 @@ from pipecat.utils.time import time_now_iso8601
 from eva.assistant.agentic.audio_llm_system import AudioLLMAgenticSystem
 from eva.assistant.agentic.audit_log import AuditLog
 from eva.assistant.pipeline.alm_base import BaseALMClient
+from eva.assistant.pipeline.fallback import TurnEndFallbackTimer, build_fallback_nudge
 from eva.assistant.pipeline.frames import LLMMessageFrame
 from eva.assistant.tools.tool_executor import ToolExecutor
 from eva.models.agents import AgentConfig
@@ -215,8 +216,17 @@ class AudioLLMProcessor(FrameProcessor):
         self._current_query_task: asyncio.Task | None = None
         self._interrupted = asyncio.Event()
 
+        # Turn-end fallback timer, owned and driven by UserObserver (set there during pipeline
+        # wiring); used here to cancel/reset on a real completed user turn.
+        self.fallback_timer: TurnEndFallbackTimer | None = None
+
         # Optional callback for transcript saving (set by pipecat_server.py)
         self.on_assistant_response: Awaitable | None = None
+
+    @property
+    def query_in_flight(self) -> bool:
+        """True while a real or nudge query is being processed (used by the fallback timer)."""
+        return self._current_query_task is not None and not self._current_query_task.done()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
         if isinstance(frame, (EndFrame, CancelFrame)):
@@ -273,6 +283,11 @@ class AudioLLMProcessor(FrameProcessor):
             except asyncio.CancelledError:
                 pass
 
+        # A real user turn landed: cancel any pending nudge and reset the give-up counter.
+        if self.fallback_timer is not None:
+            self.fallback_timer.cancel()
+            self.fallback_timer.reset_counter()
+
         self._interrupted.clear()
         logger.info(f"Processing audio-LLM user turn ({len(audio_bytes)} bytes)")
 
@@ -317,6 +332,50 @@ class AudioLLMProcessor(FrameProcessor):
             except Exception:
                 logger.debug("Failed to send error message (pipeline may be closed)")
 
+    async def process_turn_fallback(self, timeout_seconds: int | None, partial: str = "") -> None:
+        """Nudge the assistant when turn-end detection times out without a completed user turn.
+
+        Called by ``UserObserver`` when the fallback timer fires. Unlike a real turn (which
+        sends buffered audio via ``process_query_with_audio``), this injects a **text** nudge
+        through the inherited ``process_query`` — there is no user audio to attach. A marker is
+        logged with ``message_type="turn_fallback"`` so metrics can skip/zero it.
+
+        Args:
+            timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
+            partial: Best-effort partial transcript (typically empty for audio-LLM, which has
+                no STT transcript on the pipeline spine).
+        """
+        self._interrupted.clear()
+        marker, nudge = build_fallback_nudge(timeout_seconds, partial)
+        self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
+
+        self._current_query_task = asyncio.create_task(self._process_text_query(nudge))
+        try:
+            await self._current_query_task
+        except asyncio.CancelledError:
+            logger.info("Turn-end fallback processing interrupted")
+        finally:
+            self._current_query_task = None
+
+    async def _process_text_query(self, text: str) -> None:
+        """Drive the audio-LLM with a text-only query (used for fallback nudges).
+
+        Uses the inherited text ``process_query`` rather than the audio path; ``log_user_input``
+        is False because the marker was already recorded by ``process_turn_fallback``.
+        """
+        try:
+            async for response in self.agentic_system.process_query(text, log_user_input=False):
+                if self._interrupted.is_set():
+                    logger.info("Skipping response - interrupted")
+                    return
+                if response:
+                    await self._handle_response(response)
+        except asyncio.CancelledError:
+            logger.debug("Fallback text query cancelled during pipeline shutdown")
+            raise
+        except Exception as e:
+            logger.error(f"Error processing fallback text query: {e}", exc_info=True)
+
     async def _handle_response(self, message: str) -> None:
         """Push response to TTS. Mirrors BenchmarkAgentProcessor._handle_response."""
         if self._interrupted.is_set():
@@ -347,6 +406,10 @@ class AudioLLMProcessor(FrameProcessor):
     async def stop(self):
         """Stop the processor and cleanup."""
         logger.info("Stopping AudioLLMProcessor...")
+
+        # Cancel any pending turn-end fallback timer (owned by UserObserver)
+        if self.fallback_timer is not None:
+            self.fallback_timer.cancel()
 
         self._interrupted.set()
         if self._current_query_task and not self._current_query_task.done():
@@ -497,6 +560,7 @@ class AudioTranscriptionProcessor(FrameProcessor):
         Args:
             audio_data: Raw PCM audio bytes to transcribe.
             timestamp: ISO8601 timestamp for the transcription.
+            source_sample_rate: Sample rate of the input audio.
             turn_id: Optional turn identifier for associating with audit log entry.
 
         Returns:

--- a/src/eva/assistant/pipeline/audio_llm_processor.py
+++ b/src/eva/assistant/pipeline/audio_llm_processor.py
@@ -191,6 +191,7 @@ class AudioLLMProcessor(FrameProcessor):
         alm_client: BaseALMClient,
         audio_collector: AudioLLMUserAudioCollector,
         output_dir: Path | None = None,
+        pre_tool_speech: str = "off",
         llm_streaming: bool = False,
         full_audio_context: bool = False,
         **kwargs,
@@ -208,6 +209,7 @@ class AudioLLMProcessor(FrameProcessor):
             audit_log=audit_log,
             alm_client=alm_client,
             output_dir=output_dir,
+            pre_tool_speech=pre_tool_speech,
             llm_streaming=llm_streaming,
             full_audio_context=full_audio_context,
         )

--- a/src/eva/assistant/pipeline/audio_llm_processor.py
+++ b/src/eva/assistant/pipeline/audio_llm_processor.py
@@ -39,7 +39,11 @@ from pipecat.utils.time import time_now_iso8601
 from eva.assistant.agentic.audio_llm_system import AudioLLMAgenticSystem
 from eva.assistant.agentic.audit_log import AuditLog
 from eva.assistant.pipeline.alm_base import BaseALMClient
-from eva.assistant.pipeline.fallback import TurnEndFallbackTimer, build_fallback_nudge
+from eva.assistant.pipeline.fallback import (
+    TurnEndFallbackTimer,
+    build_fallback_nudge,
+    emit_emulated_user_turn_boundary,
+)
 from eva.assistant.pipeline.frames import LLMMessageFrame
 from eva.assistant.tools.tool_executor import ToolExecutor
 from eva.models.agents import AgentConfig
@@ -335,23 +339,49 @@ class AudioLLMProcessor(FrameProcessor):
                 logger.debug("Failed to send error message (pipeline may be closed)")
 
     async def process_turn_fallback(self, timeout_seconds: int | None, partial: str = "") -> None:
-        """Nudge the assistant when turn-end detection times out without a completed user turn.
+        """End the user turn on the backstop timer and reply, framed as a fallback.
 
-        Called by ``UserObserver`` when the fallback timer fires. Unlike a real turn (which
-        sends buffered audio via ``process_query_with_audio``), this injects a **text** nudge
-        through the inherited ``process_query`` — there is no user audio to attach. A marker is
-        logged with ``message_type="turn_fallback"`` so metrics can skip/zero it.
+        Called by ``UserObserver`` when the fallback timer fires. The fallback is the VAD's
+        backup turn-end decision: it takes whatever the user actually said and treats it as the
+        (possibly incomplete) user utterance. To mirror the cascade path — which forwards the
+        partial *transcript* — audio-LLM forwards the buffered partial **audio** with an
+        acknowledgment hint, so the model owns that it may not have heard perfectly before
+        answering. Only when no audio was captured at all does it fall back to a text reprompt.
+
+        Audio-LLM finalizes turns via the collector's ``LLMContextFrame`` (its
+        ``on_user_turn_stopped`` is a no-op), so it can't use the cascade's native turn-stop
+        trigger; the emulated boundary provides the turn bracketing instead.
 
         Args:
             timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
-            partial: Best-effort partial transcript (typically empty for audio-LLM, which has
-                no STT transcript on the pipeline spine).
+            partial: Best-effort partial transcript (usually empty for audio-LLM; the audio is
+                the real partial context).
         """
         self._interrupted.clear()
-        marker, nudge = build_fallback_nudge(timeout_seconds, partial)
-        self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
+        # Emulated boundary brackets this nudge as its own turn (see emit_emulated_user_turn_boundary).
+        await emit_emulated_user_turn_boundary(self)
 
-        self._current_query_task = asyncio.create_task(self._process_text_query(nudge))
+        # The fallback IS the backup end-of-utterance decision, so consume the buffer like a real
+        # turn (get_buffered_audio clears it). Otherwise consecutive nudges would re-forward the
+        # same audio, since the buffer only clears on the next UserStartedSpeakingFrame. Safe to
+        # clear: the transcription branch only reads on a real LLMContextFrame, which the fallback
+        # never emits.
+        audio_bytes = self.audio_collector.get_buffered_audio()
+        has_audio = bool(audio_bytes) and len(audio_bytes) >= MIN_AUDIO_BYTES
+        marker, nudge = build_fallback_nudge(timeout_seconds, partial, has_audio=has_audio)
+
+        if has_audio:
+            # Forward the partial audio with the acknowledgment hint. The visible audit value is
+            # the clear fallback marker; llm_content is the placeholder that _execute_agent_with_audio
+            # swaps for the audio. No turn_id, so a late transcription can't overwrite the marker.
+            self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=self._USER_PLACEHOLDER)
+            self.agentic_system.set_turn_text_hint(nudge)
+            source_sample_rate = self.audio_collector.frame_sample_rate
+            self._current_query_task = asyncio.create_task(self._process_audio_turn(audio_bytes, source_sample_rate))
+        else:
+            # No audio captured at all — reprompt via text.
+            self.audit_log.append_user_input(marker, message_type="turn_fallback", llm_content=nudge)
+            self._current_query_task = asyncio.create_task(self._process_text_query(nudge))
         try:
             await self._current_query_task
         except asyncio.CancelledError:

--- a/src/eva/assistant/pipeline/audio_llm_processor.py
+++ b/src/eva/assistant/pipeline/audio_llm_processor.py
@@ -338,7 +338,9 @@ class AudioLLMProcessor(FrameProcessor):
             except Exception:
                 logger.debug("Failed to send error message (pipeline may be closed)")
 
-    async def process_turn_fallback(self, timeout_seconds: int | None, partial: str = "") -> None:
+    async def process_turn_fallback(
+        self, timeout_seconds: int | None, partial: str = "", turn_stop_strategy=None
+    ) -> None:
         """End the user turn on the backstop timer and reply, framed as a fallback.
 
         Called by ``UserObserver`` when the fallback timer fires. The fallback is the VAD's
@@ -356,6 +358,7 @@ class AudioLLMProcessor(FrameProcessor):
             timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
             partial: Best-effort partial transcript (usually empty for audio-LLM; the audio is
                 the real partial context).
+            turn_stop_strategy: Unused for audio-LLM (cascade-only parameter for compatibility).
         """
         self._interrupted.clear()
         # Emulated boundary brackets this nudge as its own turn (see emit_emulated_user_turn_boundary).

--- a/src/eva/assistant/pipeline/fallback.py
+++ b/src/eva/assistant/pipeline/fallback.py
@@ -1,0 +1,144 @@
+"""Turn-end fallback: nudge the assistant to reprompt when a user turn is never detected.
+
+The assistant normally responds only when the pipeline detects a completed user turn.
+When VAD / turn detection silently drops a real user utterance (observed in the wild: the
+caller speaks but no turn-start/turn-end fires, so nothing is ever processed), the call
+would otherwise hang until the provider's inactivity backstop ends it ~2 minutes later.
+
+This module provides a shared timer that arms once the assistant stops speaking and, after
+``turn_end_fallback_time`` seconds of no detected user turn, fires a nudge asking the caller
+to repeat. It is hosted on the pipeline spine (``UserObserver``) so it works for both the
+cascade and audio-LLM pipelines, and it invokes a pipeline-specific ``process_turn_fallback``
+to actually inject the nudge (the two pipelines drive the model differently).
+"""
+
+import asyncio
+
+from eva.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Give up after this many consecutive nudges without the user coming back, then let the
+# provider's inactivity backstop end the call (the pre-fallback behavior).
+MAX_CONSECUTIVE_FALLBACK_NUDGES = 3
+
+
+def build_fallback_nudge(timeout_seconds: int | None, partial: str) -> tuple[str, str]:
+    """Build the (marker, llm_content) pair for a turn-end fallback nudge.
+
+    The marker is a plain transcript entry (recorded with ``message_type="turn_fallback"``
+    so downstream metrics can identify and zero it). The llm_content is the richer prompt
+    actually sent to the model.
+
+    Args:
+        timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
+        partial: Best-effort partial user transcription captured since the assistant last
+            spoke; empty string if none.
+
+    Returns:
+        ``(marker, llm_content)``.
+    """
+    if partial:
+        marker = f"turn-end not detected within {timeout_seconds}s; partial user speech: {partial!r}"
+        nudge = (
+            f"[Turn-end detection timed out after {timeout_seconds}s. The user may not have "
+            f"finished speaking and this transcription may be incomplete: {partial!r}. "
+            "If it is clear enough, respond to it; otherwise briefly ask the caller to finish "
+            "or repeat, continuing in the same language and tone as the conversation so far. "
+            "Do not mention this system note.]"
+        )
+    else:
+        marker = f"no user speech detected within {timeout_seconds}s"
+        nudge = (
+            f"[Turn-end detection timed out after {timeout_seconds}s with no user speech "
+            "captured. Briefly ask the caller to repeat what they said, continuing in the "
+            "same language and tone as the conversation so far. Do not mention this system note.]"
+        )
+    return marker, nudge
+
+
+class TurnEndFallbackTimer:
+    """A single-shot timer that fires a nudge after a window of undetected user silence.
+
+    Owns the timer task and the consecutive-nudge give-up counter. Arm/cancel are driven by
+    the host processor from pipeline frames: arm when the assistant stops speaking, cancel
+    when the assistant or the user starts speaking, re-arm when the user stops speaking
+    without a completed turn. When the window elapses, ``on_fire`` is awaited.
+
+    No-op when ``fallback_time`` is ``None`` (feature disabled), preserving the old behavior
+    of waiting for the provider's inactivity timeout.
+    """
+
+    def __init__(
+        self,
+        fallback_time: int | None,
+        on_fire,
+        max_consecutive_nudges: int = MAX_CONSECUTIVE_FALLBACK_NUDGES,
+    ) -> None:
+        """Initialize the timer.
+
+        Args:
+            fallback_time: Seconds of undetected user silence after the assistant stops
+                speaking before firing. ``None`` disables the timer.
+            on_fire: Async callable ``on_fire(timeout_seconds)`` invoked when the window
+                elapses. Should perform the pipeline-specific nudge.
+            max_consecutive_nudges: Give up after this many consecutive nudges without a
+                real user turn resetting the counter.
+        """
+        self._fallback_time = fallback_time
+        self._on_fire = on_fire
+        self._max_consecutive_nudges = max_consecutive_nudges
+        self._timer_task: asyncio.Task | None = None
+        self._consecutive_nudges = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._fallback_time is not None
+
+    def arm(self) -> None:
+        """Start a fresh timer. No-op when disabled. Cancels any previously armed timer."""
+        if self._fallback_time is None:
+            return
+        self.cancel()
+        self._timer_task = asyncio.create_task(self._run())
+
+    def cancel(self) -> None:
+        """Cancel a pending timer, if any."""
+        if self._timer_task and not self._timer_task.done():
+            self._timer_task.cancel()
+        self._timer_task = None
+
+    def reset_counter(self) -> None:
+        """Reset the consecutive-nudge counter (call when a real user turn lands)."""
+        self._consecutive_nudges = 0
+
+    def note_nudge(self) -> bool:
+        """Record that a nudge is about to fire; return False if the give-up limit is hit.
+
+        Increments the consecutive-nudge counter. Returns True if the nudge should proceed,
+        False if the limit has been exceeded (caller should skip and leave the call to the
+        inactivity backstop).
+        """
+        self._consecutive_nudges += 1
+        if self._consecutive_nudges > self._max_consecutive_nudges:
+            logger.warning(
+                f"Turn-end fallback exhausted after {self._max_consecutive_nudges} consecutive "
+                "nudges without a user turn; leaving the call to the inactivity backstop"
+            )
+            return False
+        return True
+
+    @property
+    def consecutive_nudges(self) -> int:
+        return self._consecutive_nudges
+
+    @property
+    def max_consecutive_nudges(self) -> int:
+        return self._max_consecutive_nudges
+
+    async def _run(self) -> None:
+        try:
+            await asyncio.sleep(self._fallback_time)
+        except asyncio.CancelledError:
+            return
+        await self._on_fire(self._fallback_time)

--- a/src/eva/assistant/pipeline/fallback.py
+++ b/src/eva/assistant/pipeline/fallback.py
@@ -14,45 +14,82 @@ to actually inject the nudge (the two pipelines drive the model differently).
 
 import asyncio
 
+from pipecat.frames.frames import UserStartedSpeakingFrame, UserStoppedSpeakingFrame
+from pipecat.processors.frame_processor import FrameDirection
+
 from eva.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+async def emit_emulated_user_turn_boundary(processor) -> None:
+    """Assert a user-turn start/stop boundary so the nudge is its own assistant turn.
+
+    The turn-end fallback is the VAD's backup: when it fires it decides the user's turn has
+    ended (we waited long enough). Pipecat's turn tracker only closes a turn when the user
+    starts speaking or an inter-turn timeout elapses; neither happens between back-to-back
+    nudges, so their TTS collapses into one tracked turn/segment. Emitting an emulated
+    user-turn boundary marks that decision explicitly.
+
+    Pushed from the model processor (``agent_processor`` / ``audio_llm_processor``), which sits
+    downstream of the user aggregator, so the aggregator does not re-flush a buffered transcript
+    as a duplicate real turn. The bot is idle when the fallback fires, so this does not interrupt
+    in-flight speech.
+    """
+    await processor.push_frame(UserStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+    await processor.push_frame(UserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+
 
 # Give up after this many consecutive nudges without the user coming back, then let the
 # provider's inactivity backstop end the call (the pre-fallback behavior).
 MAX_CONSECUTIVE_FALLBACK_NUDGES = 3
 
 
-def build_fallback_nudge(timeout_seconds: int | None, partial: str) -> tuple[str, str]:
+def build_fallback_nudge(timeout_seconds: int | None, partial: str, has_audio: bool = False) -> tuple[str, str]:
     """Build the (marker, llm_content) pair for a turn-end fallback nudge.
 
     The marker is a plain transcript entry (recorded with ``message_type="turn_fallback"``
     so downstream metrics can identify and zero it). The llm_content is the richer prompt
     actually sent to the model.
 
+    Three cases, in priority order:
+      1. ``partial`` text present (cascade) — embed the partial transcript.
+      2. no text but ``has_audio`` (audio-LLM) — the partial context is the buffered audio
+         itself, forwarded separately; no transcript to embed.
+      3. neither — nothing was captured, so ask the caller to repeat.
+
     Args:
         timeout_seconds: The configured ``EVA_TURN_END_FALLBACK_TIME`` value.
-        partial: Best-effort partial user transcription captured since the assistant last
-            spoke; empty string if none.
+        partial: Best-effort partial user transcription; empty string if none.
+        has_audio: True when partial user *audio* was captured (audio-LLM) even without a
+            transcript, so the nudge should acknowledge-and-answer rather than ask to repeat.
 
     Returns:
         ``(marker, llm_content)``.
     """
     if partial:
-        marker = f"turn-end not detected within {timeout_seconds}s; partial user speech: {partial!r}"
+        marker = f"[TURN-END FALLBACK after {timeout_seconds}s] partial user speech: {partial!r}"
         nudge = (
-            f"[Turn-end detection timed out after {timeout_seconds}s. The user may not have "
-            f"finished speaking and this transcription may be incomplete: {partial!r}. "
-            "If it is clear enough, respond to it; otherwise briefly ask the caller to finish "
-            "or repeat, continuing in the same language and tone as the conversation so far. "
-            "Do not mention this system note.]"
+            f"[Turn-end detection timed out after {timeout_seconds}s, so the caller's message may "
+            f"be incomplete or imperfectly transcribed: {partial!r}. Begin your reply by briefly "
+            "acknowledging you may not have heard perfectly, then answer or address what you did hear, "
+            "continuing in the same language and tone as the conversation so far. Do not mention timeouts, "
+            "transcription, or this system note.]"
+        )
+    elif has_audio:
+        marker = f"[TURN-END FALLBACK after {timeout_seconds}s] partial user audio (no transcript)"
+        nudge = (
+            f"[Turn-end detection timed out after {timeout_seconds}s, so the caller's audio may be "
+            "incomplete or imperfectly heard. Begin your reply by briefly acknowledging you may not "
+            "have heard perfectly, then answer or address what you did hear, continuing in the same "
+            "language and tone as the conversation so far. Do not mention timeouts or this system note.]"
         )
     else:
-        marker = f"no user speech detected within {timeout_seconds}s"
+        marker = f"[TURN-END FALLBACK after {timeout_seconds}s] no user speech captured"
         nudge = (
-            f"[Turn-end detection timed out after {timeout_seconds}s with no user speech "
-            "captured. Briefly ask the caller to repeat what they said, continuing in the "
-            "same language and tone as the conversation so far. Do not mention this system note.]"
+            f"[Turn-end detection timed out after {timeout_seconds}s and no user speech was "
+            "captured. Briefly acknowledge you may not have heard them and ask them to repeat, continuing in the same language "
+            "and tone as the conversation so far. Do not mention timeouts or this system note.]"
         )
     return marker, nudge
 

--- a/src/eva/assistant/pipeline/fallback.py
+++ b/src/eva/assistant/pipeline/fallback.py
@@ -127,17 +127,42 @@ class TurnEndFallbackTimer:
         self._max_consecutive_nudges = max_consecutive_nudges
         self._timer_task: asyncio.Task | None = None
         self._consecutive_nudges = 0
+        self._shutting_down = False
 
     @property
     def enabled(self) -> bool:
         return self._fallback_time is not None
 
+    @property
+    def shutting_down(self) -> bool:
+        """True once the call is ending; no further nudge may be armed or fired."""
+        return self._shutting_down
+
     def arm(self) -> None:
-        """Start a fresh timer. No-op when disabled. Cancels any previously armed timer."""
-        if self._fallback_time is None:
+        """Start a fresh timer. No-op when disabled or shutting down.
+
+        Cancels any previously armed timer.
+        """
+        if self._fallback_time is None or self._shutting_down:
             return
         self.cancel()
         self._timer_task = asyncio.create_task(self._run())
+
+    def shutdown(self) -> None:
+        """Latch the call as ending: cancel any pending timer and refuse to arm again.
+
+        The nudge exists to rescue a *live* call whose turn detection dropped a user
+        utterance. Once the call is ending, remaining silence is terminal — the user
+        simulator is gone and will never speak again — so a nudge here produces a
+        phantom assistant turn after the conversation is logically closed (scored 0).
+
+        This is a one-way latch rather than a plain ``cancel()`` because teardown keeps
+        producing frames that would otherwise re-arm: the assistant's own TTS is still
+        draining, so a trailing ``BotStoppedSpeakingFrame`` typically lands *after* the
+        end/cancel frame.
+        """
+        self._shutting_down = True
+        self.cancel()
 
     def cancel(self) -> None:
         """Cancel a pending timer, if any."""
@@ -177,5 +202,9 @@ class TurnEndFallbackTimer:
         try:
             await asyncio.sleep(self._fallback_time)
         except asyncio.CancelledError:
+            return
+        # Re-check: shutdown may have latched while this timer was sleeping, in the window
+        # between the sleep waking and cancel() reaching us.
+        if self._shutting_down:
             return
         await self._on_fire(self._fallback_time)

--- a/src/eva/metrics/base.py
+++ b/src/eva/metrics/base.py
@@ -90,6 +90,7 @@ class MetricContext:
         latency_assistant_turns: dict[int, float] | None = None,
         assistant_interrupted_turns: set[int] | None = None,
         user_interrupted_turns: set[int] | None = None,
+        fallback_turn_ids: set[int] | None = None,
         pipeline_type: PipelineType = PipelineType.CASCADE,
         language: str = "en",
     ):
@@ -143,6 +144,8 @@ class MetricContext:
         self.latency_assistant_turns = latency_assistant_turns or {}
         self.assistant_interrupted_turns = assistant_interrupted_turns or set()
         self.user_interrupted_turns = user_interrupted_turns or set()
+        # Turn ids with no real user speech - the assistant was nudged via EVA_TURN_END_FALLBACK_TIME.
+        self.fallback_turn_ids = fallback_turn_ids or set()
         self.pipeline_type = pipeline_type
 
     @property

--- a/src/eva/metrics/experience/turn_taking.py
+++ b/src/eva/metrics/experience/turn_taking.py
@@ -35,6 +35,8 @@ Flat headline sub-metrics (one number each — show up as columns in analysis vi
                         user_interruption.mean_yield_ms,
                         user_interruption.mean_yield_score
                         (the latter two only when rate > 0)
+  Fallback nudges:      fallback_nudge.rate (nudged assistant turns / total assistant turns),
+                        fallback_nudge.count (raw count; None when zero)
 
 All reported sub-metrics are consistent with the main score: ``mean_overlap_score``,
 ``mean_count_score``, and ``mean_yield_score`` aggregate exactly the per-turn scores
@@ -429,6 +431,20 @@ class TurnTakingMetric(CodeMetric):
             sub["user_interruption.mean_yield_score"] = _wrap(
                 "user_interruption.mean_yield_score", round(statistics.mean(yield_scores), 4), True
             )
+
+        # --- Turn-end fallback nudges ---
+        # Denominator is all assistant turns (not turn_keys/total_turns), since a fallback nudge
+        # produces an assistant turn with no paired user turn and so is never in turn_keys.
+        total_assistant_turns = len(context.audio_timestamps_assistant_turns)
+        if total_assistant_turns:
+            sub["fallback_nudge.rate"] = _wrap(
+                "fallback_nudge.rate", round(len(context.fallback_turn_ids) / total_assistant_turns, 4), True
+            )
+        sub["fallback_nudge.count"] = MetricScore(
+            name=f"{cls.name}.fallback_nudge.count",
+            score=float(len(context.fallback_turn_ids)) if context.fallback_turn_ids else None,
+            normalized_score=None,
+        )
 
         # Token usage (from agent_perf_stats.csv)
         mean_output_tokens = mean_agent_perf_stat(context.output_dir, "output_tokens")

--- a/src/eva/metrics/experience/turn_taking.py
+++ b/src/eva/metrics/experience/turn_taking.py
@@ -37,13 +37,19 @@ Flat headline sub-metrics (one number each — show up as columns in analysis vi
                         (the latter two only when rate > 0)
   Fallback nudges:      fallback_nudge.rate (nudged assistant turns / total assistant turns),
                         fallback_nudge.count (raw count; None when zero)
+  Pre-tool speech:      pretoolspeech_rate (lead-in tool-call groups / total tool-call groups;
+                        computed from audit_log.json directly so it works uniformly across
+                        cascade/S2S/audio-LLM; omitted when there are no tool calls or the
+                        audit log is unavailable — see ``_compute_pre_tool_speech_groups``)
 
 All reported sub-metrics are consistent with the main score: ``mean_overlap_score``,
 ``mean_count_score``, and ``mean_yield_score`` aggregate exactly the per-turn scores
 that feed into ``turn_taking.score``.
 """
 
+import json
 import statistics
+from pathlib import Path
 from typing import Any
 
 from eva.metrics.base import CodeMetric, MetricContext
@@ -61,7 +67,7 @@ class TurnTakingMetric(CodeMetric):
     description = "Turn-taking evaluation based on per-turn latency and interruption behavior"
     category = "experience"
     pass_at_k_threshold = 0.8
-    version = "v0.2"
+    version = "v0.3"
 
     # --- Latency curve (piecewise linear). 0 outside [LATENCY_HARD_EARLY_MS, LATENCY_HARD_LATE_MS]. ---
     # Ramp up 0 → 1 from LATENCY_HARD_EARLY_MS to LATENCY_SWEET_SPOT_LOW_MS.
@@ -236,6 +242,64 @@ class TurnTakingMetric(CodeMetric):
         user_barge_in = u_segs[0][0]
         agent_stopped = prev_a_segs[-1][1]
         return max(0.0, agent_stopped - user_barge_in) * 1000
+
+    @staticmethod
+    def _compute_pre_tool_speech_groups(context: MetricContext) -> list[bool] | None:
+        """Return one bool per contiguous run ("group") of tool_call/tool_response entries.
+
+        True when the assistant spoke (non-empty content) since the previous group ended (or
+        since the start of the conversation) — i.e. it gave a pre-tool-speech lead-in before this
+        group of tool calls. Consecutive tool calls with no intervening speech (e.g. two tools
+        invoked back-to-back off one lead-in) count as a single group, matching the
+        "one lead-in per batch" prompt instruction (``agent.pre_tool_speech`` in
+        configs/prompts/simulation.yaml) — a multi-tool turn with one lead-in isn't penalized for
+        the tools that didn't get their own.
+
+        Reads ``audit_log.json`` directly from ``context.output_dir`` instead of
+        ``context.conversation_trace``. The audit log carries every event's true, original
+        timestamp (when the assistant actually generated/spoke the text), whereas for S2S
+        ``conversation_trace`` assistant entries come from the user simulator's STT transcription
+        of the spoken audio — timestamped only after the audio finishes playing. That transcription
+        can sort *after* a subsequent tool_call in the timestamp-ordered trace even when the agent
+        actually spoke first (confirmed against a real S2S transcript), so ``conversation_trace``
+        order cannot be trusted for this signal on S2S. Reading the audit log directly sidesteps
+        that entirely and works uniformly across cascade, S2S, and audio-LLM.
+
+        Returns None when ``audit_log.json`` is missing, unreadable, or has no transcript — callers
+        should treat that as "unknown" rather than "no lead-ins".
+        """
+        audit_log_path = Path(context.output_dir) / "audit_log.json"
+        try:
+            with open(audit_log_path) as f:
+                audit_log = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        transcript = audit_log.get("transcript")
+        if not transcript:
+            return None
+
+        groups: list[bool] = []
+        in_group = False
+        spoke_since_group = False
+        for entry in sorted(transcript, key=lambda e: int(e["timestamp"])):
+            message_type = entry.get("message_type")
+            if message_type in ("tool_call", "tool_response"):
+                if not in_group:
+                    groups.append(spoke_since_group)
+                    in_group = True
+                continue
+            # Ignore other event types (e.g. llm_call) without breaking the current group —
+            # only assistant/user speech should reset or extend the "spoke since group" state.
+            if message_type not in ("assistant", "user"):
+                continue
+            in_group = False
+            if message_type == "assistant":
+                content = entry.get("value", "")
+                if isinstance(content, str) and content.strip():
+                    spoke_since_group = True
+            else:
+                spoke_since_group = False
+        return groups
 
     @classmethod
     def _per_turn_score_and_reason(
@@ -445,6 +509,17 @@ class TurnTakingMetric(CodeMetric):
             score=float(len(context.fallback_turn_ids)) if context.fallback_turn_ids else None,
             normalized_score=None,
         )
+
+        # --- Pre-tool-speech lead-in rate ---
+        # None (omitted) for S2S — see _compute_pre_tool_speech_groups docstring for why trace
+        # order can't be trusted there yet.
+        pre_tool_groups = cls._compute_pre_tool_speech_groups(context)
+        if pre_tool_groups:
+            sub["pretoolspeech_rate"] = _wrap(
+                "pretoolspeech_rate",
+                round(sum(pre_tool_groups) / len(pre_tool_groups), 4),
+                True,
+            )
 
         # Token usage (from agent_perf_stats.csv)
         mean_output_tokens = mean_agent_perf_stat(context.output_dir, "output_tokens")

--- a/src/eva/metrics/experience/turn_taking.py
+++ b/src/eva/metrics/experience/turn_taking.py
@@ -59,7 +59,7 @@ class TurnTakingMetric(CodeMetric):
     description = "Turn-taking evaluation based on per-turn latency and interruption behavior"
     category = "experience"
     pass_at_k_threshold = 0.8
-    version = "v0.1"
+    version = "v0.2"
 
     # --- Latency curve (piecewise linear). 0 outside [LATENCY_HARD_EARLY_MS, LATENCY_HARD_LATE_MS]. ---
     # Ramp up 0 → 1 from LATENCY_HARD_EARLY_MS to LATENCY_SWEET_SPOT_LOW_MS.
@@ -456,11 +456,25 @@ class TurnTakingMetric(CodeMetric):
             per_turn_evidence: dict[int, dict[str, Any]] = {}
             for t in turn_keys:
                 _has_tool = t in turns_with_tool_calls
+                if t in context.fallback_turn_ids:
+                    # No real user turn was ever detected within the fallback window on this
+                    # turn - always a failure, regardless of any later latency/interrupt signal.
+                    per_turn_score[t] = 0.0
+                    per_turn_reason[t] = "turn_end_fallback"
+                    per_turn_evidence[t] = {"has_tool_call": _has_tool}
+                    continue
                 score, reason, evidence = self._per_turn_score_and_reason(context, t, has_tool_call=_has_tool)
                 evidence["has_tool_call"] = _has_tool
                 per_turn_score[t] = round(score, 4)
                 per_turn_reason[t] = reason
                 per_turn_evidence[t] = evidence
+
+            # Fallback turns that never got a real (user, assistant) audio pairing at all still
+            # count as a turn-taking failure for that turn.
+            for t in sorted(context.fallback_turn_ids - set(per_turn_score)):
+                per_turn_score[t] = 0.0
+                per_turn_reason[t] = "turn_end_fallback"
+                per_turn_evidence[t] = {"has_tool_call": t in turns_with_tool_calls}
 
             total_turns = max(
                 max(context.audio_timestamps_user_turns, default=0),

--- a/src/eva/metrics/processor.py
+++ b/src/eva/metrics/processor.py
@@ -155,6 +155,11 @@ class _TurnExtractionState:
     # the user is interrupting the assistant (assistant_audio_open), this is the same utterance — skip the advance so
     # user_speech lands at the same turn.
     rollback_advance_consumed_by_user: bool = False
+    # Set when a turn_fallback marker is seen so the next assistant entry (the nudge reprompt)
+    # is tagged as a fallback utterance. Such entries are preserved in the conversation trace
+    # even when TTS-segment validation fails — consecutive nudges can share one merged pipecat
+    # segment, which would otherwise drop the second nudge and collapse two user turns together.
+    next_assistant_is_fallback: bool = False
 
     def advance_turn_if_needed(self, from_audio_start: bool = False, bypass_hold: bool = False) -> None:
         """Advance turn if the assistant responded since the last user event.
@@ -303,21 +308,28 @@ def _handle_audit_log_event(
                 annotate_last_entry(
                     conversation_trace, turn, "user", user_entry_type, AnnotationLabel.CUT_OFF_BY_ASSISTANT
                 )
-        conversation_trace.append(
-            {
-                "role": "assistant",
-                "content": content,
-                "timestamp": event["timestamp_ms"],
-                "type": "intended",
-                "turn_id": turn,
-                "_audit_source": True,
-            }
-        )
+        entry = {
+            "role": "assistant",
+            "content": content,
+            "timestamp": event["timestamp_ms"],
+            "type": "intended",
+            "turn_id": turn,
+            "_audit_source": True,
+        }
+        # A turn-end fallback nudge is a real assistant utterance (the reprompt). Tag it so
+        # validation keeps it even if its TTS segments were merged onto a neighboring turn.
+        if state.next_assistant_is_fallback:
+            entry["_fallback_nudge"] = True
+            state.next_assistant_is_fallback = False
+        conversation_trace.append(entry)
 
     elif event["event_type"] == "turn_fallback":
         # No real user speech arrived within the fallback window - the pending turn hasn't
         # advanced, so this marks the still-open user turn as one with no real transcript/audio.
+        # The nudge reprompt that follows is a genuine assistant turn: flag it so it is not
+        # dropped in trace validation.
         context.fallback_turn_ids.add(state.turn_num)
+        state.next_assistant_is_fallback = True
 
     elif event["event_type"] in ("tool_call", "tool_response"):
         state.assistant_processed_in_turn = True
@@ -575,6 +587,7 @@ def _validate_conversation_trace(
         pipecat_segments = context._intended_assistant_segments.get(turn_id, [])
         audit_text = entry.get("content", "")
         truncated = truncate_to_spoken(audit_text, pipecat_segments)
+        is_fallback = entry.pop("_fallback_nudge", False)
         if truncated is not None:
             if truncated != audit_text:
                 logger.warning(
@@ -582,6 +595,13 @@ def _validate_conversation_trace(
                     f"at turn {turn_id}/{len(context.intended_assistant_turns)}: {audit_text[:80]!r} -> {truncated[:80]!r}"
                 )
             entry["content"] = truncated
+            entry.pop("_audit_source")
+            validated_trace.append(entry)
+        elif is_fallback:
+            # A fallback nudge that reached this stage was actually spoken (unspoken nudges are
+            # rolled out of the audit log upstream). Consecutive nudges can share one merged
+            # pipecat segment on a neighboring turn, so segment validation may find no match here.
+            # Keep the nudge rather than dropping it and collapsing the surrounding user turns.
             entry.pop("_audit_source")
             validated_trace.append(entry)
         else:

--- a/src/eva/metrics/processor.py
+++ b/src/eva/metrics/processor.py
@@ -314,6 +314,11 @@ def _handle_audit_log_event(
             }
         )
 
+    elif event["event_type"] == "turn_fallback":
+        # No real user speech arrived within the fallback window - the pending turn hasn't
+        # advanced, so this marks the still-open user turn as one with no real transcript/audio.
+        context.fallback_turn_ids.add(state.turn_num)
+
     elif event["event_type"] in ("tool_call", "tool_response"):
         state.assistant_processed_in_turn = True
         conversation_trace.append(get_entry_for_audit_log(event, state.turn_num))
@@ -772,6 +777,10 @@ class _ProcessorContext:
         # Interruption data
         self.assistant_interrupted_turns: set[int] = set()
         self.user_interrupted_turns: set[int] = set()
+
+        # Turn ids where no real user speech arrived within EVA_TURN_END_FALLBACK_TIME and the
+        # assistant was nudged to retry instead. No real transcript/audio exists for these turns.
+        self.fallback_turn_ids: set[int] = set()
 
         # Conversation metadata
         self.conversation_ended_reason: str | None = None

--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -295,13 +295,12 @@ class ModelConfig(BaseModel):
         allowed = {"off", "auto"}
         if self.pre_tool_speech not in allowed:
             raise ValueError(f"pre_tool_speech must be one of {sorted(allowed)}, got '{self.pre_tool_speech}'")
-        # llm_streaming is honored by AUDIO_LLM too (via BaseALMClient.complete_stream); only
-        # pre_tool_speech / parallel_tool_calls remain CASCADE-only.
-        cascade_only_set = self.pre_tool_speech != "off" or self.parallel_tool_calls is not None
-        if cascade_only_set and self.pipeline_type != PipelineType.CASCADE:
+        # pre_tool_speech is honored by both CASCADE and AUDIO_LLM; llm_streaming by both
+        # (via BaseALMClient.complete_stream); only parallel_tool_calls remains CASCADE-only.
+        if self.parallel_tool_calls is not None and self.pipeline_type != PipelineType.CASCADE:
             logger.warning(
-                "Cascade LLM flags (pre_tool_speech / parallel_tool_calls) apply only to the CASCADE "
-                f"pipeline; they will be ignored for pipeline_type={self.pipeline_type}."
+                "parallel_tool_calls applies only to the CASCADE pipeline; it will be ignored "
+                f"for pipeline_type={self.pipeline_type}."
             )
         return self
 

--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -611,6 +611,16 @@ class RunConfig(BaseSettings):
         le=10000,
         description="Max conversation duration in seconds",
     )
+    turn_end_fallback_time: int | None = Field(
+        None,
+        ge=1,
+        description=(
+            "Seconds of user-turn inactivity after which the assistant is nudged to retry "
+            "('try again, I didn't catch that') instead of waiting for the old hard "
+            "inactivity timeout. When unset, falls back to the old behavior of ending the "
+            "conversation after the provider's inactivity timeout elapses."
+        ),
+    )
 
     # Output
     output_dir: Path = Field(

--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -629,9 +629,11 @@ class RunConfig(BaseSettings):
         None,
         ge=1,
         description=(
-            "Seconds of user-turn inactivity after which the assistant is nudged to retry "
-            "('try again, I didn't catch that') instead of waiting for the old hard "
-            "inactivity timeout. When unset, falls back to the old behavior of ending the "
+            "Seconds of user silence after the assistant stops speaking before nudging it to "
+            "reprompt the caller ('sorry, I didn't catch that'), instead of waiting for the old "
+            "hard inactivity timeout. Cancelled the moment the user starts speaking, so it only "
+            "fires when turn detection drops a user turn. Applies to the Pipecat cascade and "
+            "audio-LLM pipelines. When unset, falls back to the old behavior of ending the "
             "conversation after the provider's inactivity timeout elapses."
         ),
     )

--- a/src/eva/orchestrator/worker.py
+++ b/src/eva/orchestrator/worker.py
@@ -307,8 +307,9 @@ class ConversationWorker:
         """Start the assistant server using the configured framework."""
         server_cls = _get_server_class(self.config.framework)
         resolved_db_path = self._materialize_resolved_scenario_db()
-        # The turn-end fallback is a cascade/Pipecat concept (VAD-driven turn detection).
-        # S2S servers handle turn-taking natively and don't accept this kwarg.
+        # The turn-end fallback applies to the Pipecat pipelines (cascade + audio-LLM), whose
+        # turn detection can drop a user turn. S2S servers handle turn-taking natively and
+        # don't accept this kwarg.
         server_kwargs: dict[str, Any] = {}
         if self.config.framework == "pipecat":
             server_kwargs["turn_end_fallback_time"] = self.config.turn_end_fallback_time

--- a/src/eva/orchestrator/worker.py
+++ b/src/eva/orchestrator/worker.py
@@ -307,6 +307,11 @@ class ConversationWorker:
         """Start the assistant server using the configured framework."""
         server_cls = _get_server_class(self.config.framework)
         resolved_db_path = self._materialize_resolved_scenario_db()
+        # The turn-end fallback is a cascade/Pipecat concept (VAD-driven turn detection).
+        # S2S servers handle turn-taking natively and don't accept this kwarg.
+        server_kwargs: dict[str, Any] = {}
+        if self.config.framework == "pipecat":
+            server_kwargs["turn_end_fallback_time"] = self.config.turn_end_fallback_time
         self._assistant_server = server_cls(
             current_date_time=self.record.current_date_time,
             pipeline_config=self.config.model,
@@ -317,6 +322,7 @@ class ConversationWorker:
             port=self.port,
             conversation_id=self.record.id,
             language=self.config.language,
+            **server_kwargs,
         )
 
         await self._assistant_server.start()

--- a/src/eva/orchestrator/worker.py
+++ b/src/eva/orchestrator/worker.py
@@ -379,6 +379,13 @@ class ConversationWorker:
             language=language,
         )
 
+        # Let the simulator tell the assistant the moment the call ends, rather than leaving it
+        # to infer that from transport disconnect — which lands after the simulator's STT grace
+        # period and provider API polling, late enough for silence-triggered assistant behavior
+        # (the turn-end fallback nudge) to fire into an already-closed conversation.
+        if self._assistant_server is not None:
+            self._user_simulator.on_conversation_ending = self._assistant_server.notify_conversation_ending
+
     def _conversation_guard_timeout_seconds(self) -> int:
         """Keep the worker guard outside the provider's timeout and cleanup window."""
         return self.config.conversation_time_limit_seconds + USER_SIMULATOR_SHUTDOWN_GRACE_SECONDS

--- a/src/eva/user_simulator/base.py
+++ b/src/eva/user_simulator/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
 
@@ -69,6 +70,13 @@ class AbstractUserSimulator(ABC):
         self._end_reason = "unknown"
         self._conversation_done = asyncio.Event()
 
+        # Set by the worker to the assistant server's notify_conversation_ending. Invoked as
+        # soon as the call is known to be over — before the STT grace period and any post-hoc
+        # provider API polling, which can keep the transport open well past that point. See
+        # signal_conversation_ending.
+        self.on_conversation_ending: Callable[[str | None], None] | None = None
+        self._ending_signaled = False
+
         self.event_logger = UserSimulatorEventLogger(
             self.output_dir / "user_simulator_events.jsonl",
             provider=provider,
@@ -113,11 +121,30 @@ class AbstractUserSimulator(ABC):
             current_date_time=self.current_date_time,
         )
 
+    def signal_conversation_ending(self, reason: str | None = None) -> None:
+        """Tell the assistant the call is over, before transport teardown begins.
+
+        Idempotent and never raises: teardown paths call this best-effort, and the assistant
+        side treats it as advisory. Call it from *every* terminal path (end_call, timeout,
+        error), since the assistant's silence-triggered behavior doesn't care why the call
+        ended — only that no further user speech is coming.
+        """
+        if self._ending_signaled:
+            return
+        self._ending_signaled = True
+        if self.on_conversation_ending is None:
+            return
+        try:
+            self.on_conversation_ending(reason or self._end_reason)
+        except Exception as e:
+            logger.warning(f"Failed to signal conversation ending to the assistant: {e}")
+
     def _on_conversation_end(self, reason: str = "goodbye") -> None:
         if not self._conversation_done.is_set():
             self._end_reason = reason
             self._conversation_done.set()
             logger.info(f"Conversation end signaled: {reason}")
+            self.signal_conversation_ending(reason)
 
     def _on_user_speaks(self, response: str) -> None:
         current_record_id.set(self._record_id)

--- a/src/eva/user_simulator/elevenlabs.py
+++ b/src/eva/user_simulator/elevenlabs.py
@@ -185,6 +185,8 @@ class ElevenLabsUserSimulator(AbstractUserSimulator):
                 logger.info(f"Conversation timed out after {self.timeout}s")
                 self._end_reason = "timeout"
                 self.event_logger.log_event("timeout", {"duration": self.timeout})
+                # _on_conversation_end never fired on this path, so signal here too.
+                self.signal_conversation_ending("timeout")
             finally:
                 # Cancel keep-alive task when conversation ends
                 keep_alive_task.cancel()
@@ -193,7 +195,11 @@ class ElevenLabsUserSimulator(AbstractUserSimulator):
                 except asyncio.CancelledError:
                     pass
 
-            # End the session
+            # End the session. Signal first (idempotent): everything below — end_session, the
+            # end_call API polling, and the STT grace sleep in the finally block — can take 10s
+            # or more, during which the transport stays open and the assistant would otherwise
+            # still consider the call live.
+            self.signal_conversation_ending()
             logger.info("Ending ElevenLabs session...")
             self._conversation.end_session()
 
@@ -221,6 +227,10 @@ class ElevenLabsUserSimulator(AbstractUserSimulator):
             self._end_reason = "error"
             raise
         finally:
+            # Backstop for paths that reached teardown without signalling (e.g. an exception
+            # raised before the normal end-of-session point). Idempotent.
+            self.signal_conversation_ending()
+
             # Save response latencies from audio interface before cleanup
             if self._audio_interface:
                 latencies = self._audio_interface.get_latencies()

--- a/tests/fixtures/metric_signatures.json
+++ b/tests/fixtures/metric_signatures.json
@@ -92,7 +92,7 @@
   "TurnTakingMetric": {
     "name": "turn_taking",
     "prompt_hash": null,
-    "source_hash": "6f7de6c7d5e4",
+    "source_hash": "5b8b27042d31",
     "version": "v0.2"
   },
   "UserBehavioralFidelityMetric": {

--- a/tests/fixtures/metric_signatures.json
+++ b/tests/fixtures/metric_signatures.json
@@ -92,8 +92,8 @@
   "TurnTakingMetric": {
     "name": "turn_taking",
     "prompt_hash": null,
-    "source_hash": "5b8b27042d31",
-    "version": "v0.2"
+    "source_hash": "70f441017c94",
+    "version": "v0.3"
   },
   "UserBehavioralFidelityMetric": {
     "name": "user_behavioral_fidelity",

--- a/tests/fixtures/metric_signatures.json
+++ b/tests/fixtures/metric_signatures.json
@@ -92,8 +92,8 @@
   "TurnTakingMetric": {
     "name": "turn_taking",
     "prompt_hash": null,
-    "source_hash": "fee8caa7adc7",
-    "version": "v0.1"
+    "source_hash": "6f7de6c7d5e4",
+    "version": "v0.2"
   },
   "UserBehavioralFidelityMetric": {
     "name": "user_behavioral_fidelity",

--- a/tests/unit/assistant/test_agent_processor_fallback.py
+++ b/tests/unit/assistant/test_agent_processor_fallback.py
@@ -38,16 +38,29 @@ SETTLE = FALLBACK_TIME + 0.03  # wait past the window for the timer to fire
 
 def test_build_fallback_nudge_no_partial():
     marker, nudge = build_fallback_nudge(4, "")
-    assert marker == "no user speech detected within 4s"
-    assert "no user speech captured" in nudge
-    assert "Do not mention this system note" in nudge
+    assert "TURN-END FALLBACK" in marker  # audit marker makes the fallback abundantly clear
+    assert "no user speech captured" in marker
+    assert "acknowledge you may not have heard" in nudge
+    assert "repeat" in nudge
+    assert "system note" in nudge
 
 
 def test_build_fallback_nudge_with_partial():
     marker, nudge = build_fallback_nudge(4, "ten o'clock")
-    assert "partial user speech" in marker
+    assert "TURN-END FALLBACK" in marker
     assert "ten o'clock" in marker
+    # The model is told to acknowledge it may have misheard, then address the partial.
+    assert "acknowledging you may not have heard" in nudge
     assert "ten o'clock" in nudge
+
+
+def test_build_fallback_nudge_audio_partial():
+    # Audio-LLM: no transcript but audio captured -> acknowledge-and-answer (not "please repeat").
+    marker, nudge = build_fallback_nudge(20, "", has_audio=True)
+    assert "TURN-END FALLBACK" in marker
+    assert "audio" in marker
+    assert "acknowledging you may not have heard" in nudge
+    assert "answer or address what you did hear" in nudge
 
 
 # --------------------------------------------------------------------------------------------
@@ -111,12 +124,17 @@ async def test_timer_reset_counter():
 # --------------------------------------------------------------------------------------------
 
 
-def _make_observer(fallback_time=FALLBACK_TIME):
+def _make_observer(fallback_time=FALLBACK_TIME, turn_stop_strategy=None):
     """Build a UserObserver with a mock fallback processor, bypassing pipecat push_frame."""
     proc = MagicMock()
     proc.query_in_flight = False
     proc.process_turn_fallback = AsyncMock()
-    obs = UserObserver(turn_end_fallback_time=fallback_time, fallback_processor=proc)
+    proc.arm_fallback = MagicMock()
+    obs = UserObserver(
+        turn_end_fallback_time=fallback_time,
+        fallback_processor=proc,
+        turn_stop_strategy=turn_stop_strategy,
+    )
     # Stub the FrameProcessor plumbing so process_frame can run outside a real pipeline.
     obs.push_frame = AsyncMock()
 
@@ -149,6 +167,44 @@ async def test_observer_fires_nudge_on_silence(monkeypatch):
     args = proc.process_turn_fallback.await_args
     assert args.args[0] == FALLBACK_TIME
     assert args.args[1] == ""
+
+
+async def test_observer_triggers_native_turn_stop_when_strategy_present(monkeypatch):
+    """Cascade prototype: with a turn_stop_strategy, the fallback rides the standard flow.
+
+    It arms the processor and fires the strategy's native turn-stop instead of the bypass
+    process_turn_fallback path.
+    """
+    strategy = MagicMock()
+    strategy.trigger_user_turn_stopped = AsyncMock()
+    obs, proc = _make_observer(turn_stop_strategy=strategy)
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    await asyncio.sleep(SETTLE)
+    strategy.trigger_user_turn_stopped.assert_awaited_once()
+    proc.arm_fallback.assert_called_once()
+    # The bypass path is not used when riding the standard flow.
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_clears_pending_fallback_on_real_turn_start(monkeypatch):
+    """Cascade: a real turn start discards a fallback armed by a prior no-op'd native turn-stop.
+
+    Guards the leak where trigger_user_turn_stopped no-ops (no open user turn), leaving
+    _pending_fallback armed to mis-frame the next genuine turn.
+    """
+    strategy = MagicMock()
+    strategy.trigger_user_turn_stopped = AsyncMock()
+    obs, proc = _make_observer(turn_stop_strategy=strategy)
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, UserStartedSpeakingFrame())
+    proc.clear_pending_fallback.assert_called_once()
 
 
 async def test_observer_user_started_speaking_cancels(monkeypatch):
@@ -237,12 +293,78 @@ async def test_observer_forwards_partial_transcript(monkeypatch):
 # --------------------------------------------------------------------------------------------
 
 
-async def test_audio_llm_process_turn_fallback_injects_text_nudge():
-    """The audio-LLM nudge logs a turn_fallback marker and drives a text query to TTS.
+async def test_process_complete_user_turn_frames_fallback(monkeypatch):
+    """Cascade prototype: an armed fallback turn is framed as a nudge via the standard handler.
 
-    Exercises the real AudioLLMProcessor.process_turn_fallback with a mocked agentic system,
-    since the example/7 end-to-end path needs a remote model endpoint not available in tests.
+    Records a turn_fallback marker, drives the model with the nudge (not as normal user input),
+    and does NOT reset the give-up counter (a fallback still counts toward the cap).
     """
+    from eva.assistant.agentic.audit_log import AuditLog
+    from eva.assistant.pipeline.agent_processor import BenchmarkAgentProcessor
+
+    proc = object.__new__(BenchmarkAgentProcessor)
+    proc._pending_fallback = (20, "buffered partial")
+    proc._current_query_task = None
+    proc._interrupted = asyncio.Event()
+    proc._user_message_aggregator = []
+    proc.audit_log = AuditLog()
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, AsyncMock())
+    timer.note_nudge()  # this fallback was counted by the observer
+    proc.fallback_timer = timer
+
+    captured = {}
+
+    async def fake_process_user_query(text, log_user_input=True):
+        captured["text"] = text
+        captured["log_user_input"] = log_user_input
+
+    proc._process_user_query = fake_process_user_query
+
+    await proc.process_complete_user_turn("partial words")  # aggregator transcript
+
+    fb = [e for e in proc.audit_log.transcript if e.get("message_type") == "turn_fallback"]
+    assert len(fb) == 1
+    assert "partial words" in fb[0]["llm_content"]  # aggregator content preferred over buffered
+    assert captured["log_user_input"] is False  # driven as a nudge, not logged as normal user input
+    assert timer.consecutive_nudges == 1  # counter NOT reset for a fallback turn
+    assert proc._pending_fallback is None  # pending consumed
+
+
+async def test_process_complete_user_turn_normal_turn_unaffected(monkeypatch):
+    """A normal (non-fallback) completed turn still behaves as before."""
+    from eva.assistant.agentic.audit_log import AuditLog
+    from eva.assistant.pipeline.agent_processor import BenchmarkAgentProcessor
+
+    proc = object.__new__(BenchmarkAgentProcessor)
+    proc._pending_fallback = None
+    proc._current_query_task = None
+    proc._interrupted = asyncio.Event()
+    proc._user_message_aggregator = []
+    proc.audit_log = AuditLog()
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, AsyncMock())
+    timer.note_nudge()
+    proc.fallback_timer = timer
+
+    captured = {}
+
+    async def fake_process_user_query(text, log_user_input=True):
+        captured["text"] = text
+        captured["log_user_input"] = log_user_input
+
+    proc._process_user_query = fake_process_user_query
+
+    await proc.process_complete_user_turn("Hello there")
+
+    assert captured["text"] == "Hello there"
+    assert captured["log_user_input"] is True
+    assert timer.consecutive_nudges == 0  # real turn resets the counter
+    assert proc._user_message_aggregator == [{"role": "user", "content": "Hello there"}]
+    # No fallback marker for a normal turn.
+    assert [e for e in proc.audit_log.transcript if e.get("message_type") == "turn_fallback"] == []
+
+
+def _make_audio_llm_proc(buffered_audio=b""):
+    """Build a bare AudioLLMProcessor with a mock audio collector for fallback tests."""
     from eva.assistant.agentic.audit_log import AuditLog
     from eva.assistant.pipeline.audio_llm_processor import AudioLLMProcessor
 
@@ -253,20 +375,67 @@ async def test_audio_llm_process_turn_fallback_injects_text_nudge():
     proc.audit_log = AuditLog()
     proc.on_assistant_response = None
     proc.push_frame = AsyncMock()
+    proc.audio_collector = MagicMock()
+    # The fallback consumes the buffer via get_buffered_audio (clear-on-read); peek is kept for
+    # the normal-turn / transcription readers.
+    proc.audio_collector.peek_buffered_audio.return_value = buffered_audio
+    proc.audio_collector.get_buffered_audio.return_value = buffered_audio
+    proc.audio_collector.frame_sample_rate = 24000
+    proc.agentic_system = MagicMock()
+    return proc
+
+
+async def test_audio_llm_fallback_text_reprompt_when_no_audio():
+    """No buffered audio -> the fallback reprompts via a text nudge (marker + acknowledge/repeat)."""
+    proc = _make_audio_llm_proc(buffered_audio=b"")
 
     async def fake_process_query(text, log_user_input=True):
         assert log_user_input is False  # marker already logged separately
-        yield "Sorry, I didn't catch that. Could you repeat?"
+        yield "Sorry, I may not have caught that. Could you repeat?"
 
-    proc.agentic_system = MagicMock()
     proc.agentic_system.process_query = fake_process_query
 
     await proc.process_turn_fallback(4, "")
 
-    # A turn_fallback marker was recorded with the richer nudge as llm_content.
     fb = [e for e in proc.audit_log.transcript if e.get("message_type") == "turn_fallback"]
     assert len(fb) == 1
-    assert fb[0]["value"] == "no user speech detected within 4s"
+    assert "TURN-END FALLBACK" in fb[0]["value"]
     assert "repeat" in fb[0]["llm_content"].lower()
-    # The response was pushed toward TTS (LLMMessageFrame + TTSSpeakFrame).
-    assert proc.push_frame.await_count >= 1
+    # Emulated boundary emitted first, then the response toward TTS.
+    from pipecat.frames.frames import UserStartedSpeakingFrame, UserStoppedSpeakingFrame
+
+    pushed = [call.args[0] for call in proc.push_frame.await_args_list]
+    assert [type(f) for f in pushed[:2]] == [UserStartedSpeakingFrame, UserStoppedSpeakingFrame]
+    assert len(pushed) > 2  # response frames followed
+
+
+async def test_audio_llm_fallback_forwards_partial_audio_with_hint():
+    """Buffered audio present -> the fallback forwards the partial AUDIO with an acknowledgment hint.
+
+    Mirrors the cascade path forwarding the partial transcript: the model gets the audio plus a
+    text hint to acknowledge it may not have heard perfectly. A clear turn_fallback marker is
+    still recorded.
+    """
+    proc = _make_audio_llm_proc(buffered_audio=b"x" * 100_000)  # well above MIN_AUDIO_BYTES
+
+    captured = {}
+    proc.agentic_system.set_turn_audio = MagicMock()
+    proc.agentic_system.set_turn_text_hint = lambda h: captured.setdefault("hint", h)
+
+    async def fake_process_query_with_audio(text):
+        yield "I may not have caught all of that, but let me help with the change."
+
+    proc.agentic_system.process_query_with_audio = fake_process_query_with_audio
+
+    await proc.process_turn_fallback(20, "")
+
+    fb = [e for e in proc.audit_log.transcript if e.get("message_type") == "turn_fallback"]
+    assert len(fb) == 1
+    assert "TURN-END FALLBACK" in fb[0]["value"]  # clear audit marker retained
+    # The partial audio was sent and an acknowledgment hint was set on the audio turn.
+    proc.agentic_system.set_turn_audio.assert_called_once()
+    assert "acknowledging you may not have heard" in captured["hint"]
+    # The buffer was consumed (cleared) so a later nudge/turn can't re-forward the same audio.
+    proc.audio_collector.get_buffered_audio.assert_called_once()
+    # A response reached TTS (boundary pushed first, then the reply).
+    assert proc.push_frame.await_count > 2

--- a/tests/unit/assistant/test_agent_processor_fallback.py
+++ b/tests/unit/assistant/test_agent_processor_fallback.py
@@ -1,0 +1,272 @@
+"""Tests for the turn-end fallback timer and its wiring into UserObserver.
+
+The fallback nudges the assistant to reprompt when a user turn is never detected within
+EVA_TURN_END_FALLBACK_TIME seconds after the assistant stops speaking. The timer is hosted on
+the pipeline spine (UserObserver) and fires a pipeline-specific process_turn_fallback.
+
+These tests drive the timer/observer directly (no real Pipecat pipeline) using a tiny window so
+they run in well under a second.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    TranscriptionFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection
+
+from eva.assistant.pipeline.agent_processor import UserObserver
+from eva.assistant.pipeline.fallback import (
+    MAX_CONSECUTIVE_FALLBACK_NUDGES,
+    TurnEndFallbackTimer,
+    build_fallback_nudge,
+)
+
+FALLBACK_TIME = 0.02  # 20ms window keeps timer tests fast
+SETTLE = FALLBACK_TIME + 0.03  # wait past the window for the timer to fire
+
+
+# --------------------------------------------------------------------------------------------
+# build_fallback_nudge
+# --------------------------------------------------------------------------------------------
+
+
+def test_build_fallback_nudge_no_partial():
+    marker, nudge = build_fallback_nudge(4, "")
+    assert marker == "no user speech detected within 4s"
+    assert "no user speech captured" in nudge
+    assert "Do not mention this system note" in nudge
+
+
+def test_build_fallback_nudge_with_partial():
+    marker, nudge = build_fallback_nudge(4, "ten o'clock")
+    assert "partial user speech" in marker
+    assert "ten o'clock" in marker
+    assert "ten o'clock" in nudge
+
+
+# --------------------------------------------------------------------------------------------
+# TurnEndFallbackTimer
+# --------------------------------------------------------------------------------------------
+
+
+async def test_timer_disabled_is_noop():
+    fired = []
+    timer = TurnEndFallbackTimer(None, lambda t: fired.append(t))
+    assert not timer.enabled
+    timer.arm()
+    await asyncio.sleep(SETTLE)
+    assert fired == []
+
+
+async def test_timer_fires_on_silence():
+    fired = []
+
+    async def on_fire(t):
+        fired.append(t)
+
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, on_fire)
+    timer.arm()
+    await asyncio.sleep(SETTLE)
+    assert fired == [FALLBACK_TIME]
+
+
+async def test_timer_cancel_prevents_fire():
+    fired = []
+
+    async def on_fire(t):
+        fired.append(t)
+
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, on_fire)
+    timer.arm()
+    timer.cancel()
+    await asyncio.sleep(SETTLE)
+    assert fired == []
+
+
+async def test_timer_note_nudge_give_up():
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, AsyncMock())
+    # First MAX nudges proceed; the one after the limit is refused.
+    for _ in range(MAX_CONSECUTIVE_FALLBACK_NUDGES):
+        assert timer.note_nudge() is True
+    assert timer.note_nudge() is False
+    assert timer.consecutive_nudges == MAX_CONSECUTIVE_FALLBACK_NUDGES + 1
+
+
+async def test_timer_reset_counter():
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, AsyncMock())
+    timer.note_nudge()
+    timer.note_nudge()
+    timer.reset_counter()
+    assert timer.consecutive_nudges == 0
+
+
+# --------------------------------------------------------------------------------------------
+# UserObserver wiring
+# --------------------------------------------------------------------------------------------
+
+
+def _make_observer(fallback_time=FALLBACK_TIME):
+    """Build a UserObserver with a mock fallback processor, bypassing pipecat push_frame."""
+    proc = MagicMock()
+    proc.query_in_flight = False
+    proc.process_turn_fallback = AsyncMock()
+    obs = UserObserver(turn_end_fallback_time=fallback_time, fallback_processor=proc)
+    # Stub the FrameProcessor plumbing so process_frame can run outside a real pipeline.
+    obs.push_frame = AsyncMock()
+
+    async def _noop_super(frame, direction):
+        return None
+
+    # super().process_frame is called first in UserObserver.process_frame; patch the bound
+    # FrameProcessor method on the instance's class chain is awkward, so monkeypatch via a flag.
+    return obs, proc
+
+
+async def _send(obs, frame):
+    # UserObserver.process_frame calls super().process_frame first; that requires pipecat setup.
+    # We bypass it by calling the frame-handling logic through the public method with the
+    # FrameProcessor base stubbed.
+    await obs.process_frame(frame, FrameDirection.DOWNSTREAM)
+
+
+async def test_observer_fires_nudge_on_silence(monkeypatch):
+    obs, proc = _make_observer()
+    # Bypass FrameProcessor.process_frame (needs a running pipeline).
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_awaited_once()
+    # partial is empty (no transcription seen)
+    args = proc.process_turn_fallback.await_args
+    assert args.args[0] == FALLBACK_TIME
+    assert args.args[1] == ""
+
+
+async def test_observer_user_started_speaking_cancels(monkeypatch):
+    """The bug-1 regression: a UserStartedSpeaking within the window suppresses the nudge."""
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    await _send(obs, UserStartedSpeakingFrame())  # should cancel
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_bot_started_speaking_cancels(monkeypatch):
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    await _send(obs, BotStartedSpeakingFrame())  # cancel (assistant speaking again)
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_rearms_on_user_stopped(monkeypatch):
+    """User stops without a completed turn (query not in flight) -> re-arm and eventually fire."""
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    await _send(obs, UserStartedSpeakingFrame())  # cancel
+    await _send(obs, UserStoppedSpeakingFrame())  # re-arm (query not in flight)
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_awaited_once()
+
+
+async def test_observer_no_rearm_when_query_in_flight(monkeypatch):
+    """Race guard: if a real turn is being processed, UserStopped must NOT re-arm a nudge."""
+    obs, proc = _make_observer()
+    proc.query_in_flight = True  # a real completed turn is being processed
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    await _send(obs, UserStartedSpeakingFrame())  # cancel
+    await _send(obs, UserStoppedSpeakingFrame())  # would re-arm, but query in flight -> skip
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_skips_nudge_when_query_in_flight(monkeypatch):
+    """If a query starts after arming, the fire handler skips (no stacked nudge)."""
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    proc.query_in_flight = True  # real turn started processing before the window elapsed
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_forwards_partial_transcript(monkeypatch):
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    await _send(obs, TranscriptionFrame("ten o'clock", "user", "2026-01-01T00:00:00Z"))
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_awaited_once()
+    args = proc.process_turn_fallback.await_args
+    assert args.args[1] == "ten o'clock"
+
+
+# --------------------------------------------------------------------------------------------
+# AudioLLMProcessor.process_turn_fallback (the audio-LLM extension)
+# --------------------------------------------------------------------------------------------
+
+
+async def test_audio_llm_process_turn_fallback_injects_text_nudge():
+    """The audio-LLM nudge logs a turn_fallback marker and drives a text query to TTS.
+
+    Exercises the real AudioLLMProcessor.process_turn_fallback with a mocked agentic system,
+    since the example/7 end-to-end path needs a remote model endpoint not available in tests.
+    """
+    from eva.assistant.agentic.audit_log import AuditLog
+    from eva.assistant.pipeline.audio_llm_processor import AudioLLMProcessor
+
+    proc = object.__new__(AudioLLMProcessor)
+    proc._current_query_task = None
+    proc._interrupted = asyncio.Event()
+    proc.fallback_timer = None
+    proc.audit_log = AuditLog()
+    proc.on_assistant_response = None
+    proc.push_frame = AsyncMock()
+
+    async def fake_process_query(text, log_user_input=True):
+        assert log_user_input is False  # marker already logged separately
+        yield "Sorry, I didn't catch that. Could you repeat?"
+
+    proc.agentic_system = MagicMock()
+    proc.agentic_system.process_query = fake_process_query
+
+    await proc.process_turn_fallback(4, "")
+
+    # A turn_fallback marker was recorded with the richer nudge as llm_content.
+    fb = [e for e in proc.audit_log.transcript if e.get("message_type") == "turn_fallback"]
+    assert len(fb) == 1
+    assert fb[0]["value"] == "no user speech detected within 4s"
+    assert "repeat" in fb[0]["llm_content"].lower()
+    # The response was pushed toward TTS (LLMMessageFrame + TTSSpeakFrame).
+    assert proc.push_frame.await_count >= 1

--- a/tests/unit/assistant/test_agent_processor_fallback.py
+++ b/tests/unit/assistant/test_agent_processor_fallback.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock
 from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
+    CancelFrame,
+    EndFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
@@ -117,6 +119,42 @@ async def test_timer_reset_counter():
     timer.note_nudge()
     timer.reset_counter()
     assert timer.consecutive_nudges == 0
+
+
+async def test_timer_shutdown_cancels_pending():
+    on_fire = AsyncMock()
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, on_fire)
+    timer.arm()
+    timer.shutdown()
+    await asyncio.sleep(SETTLE)
+    on_fire.assert_not_awaited()
+    assert timer.shutting_down
+
+
+async def test_timer_shutdown_blocks_rearm():
+    """The end-of-call regression: teardown frames must not re-arm after shutdown.
+
+    The assistant's TTS is still draining when the call ends, so a trailing
+    BotStoppedSpeakingFrame typically lands *after* the end/cancel frame. A plain cancel()
+    would be undone by it; the latch must make arm() a permanent no-op.
+    """
+    on_fire = AsyncMock()
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, on_fire)
+    timer.shutdown()
+    timer.arm()  # simulates the late BotStoppedSpeakingFrame
+    await asyncio.sleep(SETTLE)
+    on_fire.assert_not_awaited()
+
+
+async def test_timer_shutdown_during_sleep_suppresses_fire():
+    """Shutdown landing while the window is already elapsing must still suppress the nudge."""
+    on_fire = AsyncMock()
+    timer = TurnEndFallbackTimer(FALLBACK_TIME, on_fire)
+    timer.arm()
+    await asyncio.sleep(FALLBACK_TIME / 2)  # mid-window
+    timer._shutting_down = True  # latch without cancelling, to exercise the _run re-check
+    await asyncio.sleep(SETTLE)
+    on_fire.assert_not_awaited()
 
 
 # --------------------------------------------------------------------------------------------
@@ -286,6 +324,91 @@ async def test_observer_forwards_partial_transcript(monkeypatch):
     proc.process_turn_fallback.assert_awaited_once()
     args = proc.process_turn_fallback.await_args
     assert args.args[1] == "ten o'clock"
+
+
+# --------------------------------------------------------------------------------------------
+# End-of-call shutdown (the phantom-turn regression)
+# --------------------------------------------------------------------------------------------
+
+
+async def test_observer_cancel_frame_disarms_fallback(monkeypatch):
+    """A CancelFrame must kill a timer armed by the assistant's last utterance.
+
+    Regression: the nudge fired ~10s after the assistant's final TTS drained, past end_call,
+    producing a phantom assistant turn in a closed conversation that scores 0.
+    """
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm, as the final TTS drains
+    await _send(obs, CancelFrame())
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_end_frame_disarms_fallback(monkeypatch):
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())
+    await _send(obs, EndFrame())
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_late_bot_stopped_after_cancel_does_not_rearm(monkeypatch):
+    """Draining TTS after the cancel frame must not resurrect the nudge."""
+    obs, proc = _make_observer()
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, CancelFrame())
+    await _send(obs, BotStoppedSpeakingFrame())  # trailing frame from draining audio
+    await asyncio.sleep(SETTLE)
+    proc.process_turn_fallback.assert_not_awaited()
+
+
+async def test_observer_shutdown_clears_pending_fallback_cascade(monkeypatch):
+    """Cascade: shutdown must also discard an armed-but-unconsumed fallback.
+
+    On this path the fire handler sets _pending_fallback then awaits a native turn-stop, so a
+    shutdown landing in between would leave the flag set to mis-frame a transcript flushed
+    during teardown as a fallback turn.
+    """
+    strategy = MagicMock()
+    strategy.trigger_user_turn_stopped = AsyncMock()
+    obs, proc = _make_observer(turn_stop_strategy=strategy)
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, CancelFrame())
+    proc.clear_pending_fallback.assert_called_once()
+
+
+async def test_observer_cascade_no_native_turn_stop_after_shutdown(monkeypatch):
+    """Cascade: no phantom *user* turn may be injected once the call is ending.
+
+    Worse than the audio-LLM case: trigger_user_turn_stopped would fabricate a user turn
+    during teardown, not just an assistant reply.
+    """
+    strategy = MagicMock()
+    strategy.trigger_user_turn_stopped = AsyncMock()
+    obs, proc = _make_observer(turn_stop_strategy=strategy)
+    monkeypatch.setattr(
+        "pipecat.processors.frame_processor.FrameProcessor.process_frame",
+        AsyncMock(),
+    )
+    await _send(obs, BotStoppedSpeakingFrame())  # arm
+    await _send(obs, CancelFrame())
+    await asyncio.sleep(SETTLE)
+    strategy.trigger_user_turn_stopped.assert_not_awaited()
+    proc.arm_fallback.assert_not_called()
 
 
 # --------------------------------------------------------------------------------------------

--- a/tests/unit/assistant/test_agent_processor_fallback.py
+++ b/tests/unit/assistant/test_agent_processor_fallback.py
@@ -210,8 +210,8 @@ async def test_observer_fires_nudge_on_silence(monkeypatch):
 async def test_observer_triggers_native_turn_stop_when_strategy_present(monkeypatch):
     """Cascade prototype: with a turn_stop_strategy, the fallback rides the standard flow.
 
-    It arms the processor and fires the strategy's native turn-stop instead of the bypass
-    process_turn_fallback path.
+    It calls process_turn_fallback with the strategy, which arms the processor and fires
+    the strategy's native turn-stop. If the native path succeeds, it returns early.
     """
     strategy = MagicMock()
     strategy.trigger_user_turn_stopped = AsyncMock()
@@ -222,10 +222,9 @@ async def test_observer_triggers_native_turn_stop_when_strategy_present(monkeypa
     )
     await _send(obs, BotStoppedSpeakingFrame())  # arm
     await asyncio.sleep(SETTLE)
-    strategy.trigger_user_turn_stopped.assert_awaited_once()
-    proc.arm_fallback.assert_called_once()
-    # The bypass path is not used when riding the standard flow.
-    proc.process_turn_fallback.assert_not_awaited()
+    # Now process_turn_fallback is always called, and it internally calls trigger_user_turn_stopped
+    # if a strategy is present.
+    proc.process_turn_fallback.assert_awaited_once()
 
 
 async def test_observer_clears_pending_fallback_on_real_turn_start(monkeypatch):
@@ -464,6 +463,8 @@ async def test_process_complete_user_turn_normal_turn_unaffected(monkeypatch):
     proc._interrupted = asyncio.Event()
     proc._user_message_aggregator = []
     proc.audit_log = AuditLog()
+    proc._pending_final_transcripts = []
+    proc._latest_interim_transcript = ""
     timer = TurnEndFallbackTimer(FALLBACK_TIME, AsyncMock())
     timer.note_nudge()
     proc.fallback_timer = timer

--- a/tests/unit/assistant/test_agent_processor_fallback.py
+++ b/tests/unit/assistant/test_agent_processor_fallback.py
@@ -168,6 +168,8 @@ def _make_observer(fallback_time=FALLBACK_TIME, turn_stop_strategy=None):
     proc.query_in_flight = False
     proc.process_turn_fallback = AsyncMock()
     proc.arm_fallback = MagicMock()
+    proc._pending_final_transcripts = []
+    proc._latest_interim_transcript = ""
     obs = UserObserver(
         turn_end_fallback_time=fallback_time,
         fallback_processor=proc,

--- a/tests/unit/assistant/test_audio_llm_system.py
+++ b/tests/unit/assistant/test_audio_llm_system.py
@@ -1,0 +1,99 @@
+"""Tests for AudioLLMAgenticSystem turn-history construction.
+
+The user can only submit audio, but a turn may carry no audio at all (genuine silence hitting
+the turn-end fallback, which reprompts via text). full_audio_context must still map each audio
+turn's audio to the correct user message: _turn_audio_history is kept aligned 1:1 with user
+messages, with None marking a no-audio turn so audio never shifts onto the wrong turn.
+"""
+
+from unittest.mock import MagicMock
+
+from eva.assistant.agentic.audio_llm_system import AudioLLMAgenticSystem
+from eva.assistant.agentic.audit_log import AuditLog
+
+
+def _make_system(full_audio_context: bool):
+    """Build a bare AudioLLMAgenticSystem with just what _execute_agent_with_audio needs."""
+    sys = object.__new__(AudioLLMAgenticSystem)
+    sys.system_prompt = "SYS"
+    sys.full_audio_context = full_audio_context
+    sys.audit_log = AuditLog()
+    sys._turn_text_hint = ""
+    sys._turn_audio_history = []
+    sys.agent = MagicMock()
+
+    alm = MagicMock()
+    alm.build_audio_user_message = lambda audio_bytes, source_sample_rate, text_hint="": {
+        "role": "user",
+        "content": [{"type": "audio", "_bytes": audio_bytes, "hint": text_hint}],
+    }
+    sys.alm_client = alm
+
+    captured = {}
+
+    async def fake_run_tool_loop(messages, agent):
+        captured["messages"] = messages
+        return
+        yield  # make it an async generator
+
+    sys._run_tool_loop = fake_run_tool_loop
+    return sys, captured
+
+
+def _user_msgs(messages):
+    return [m for m in messages if m.get("role") == "user"]
+
+
+async def test_full_audio_context_aligns_audio_across_silence_fallback():
+    """A no-audio (silence) fallback in the middle must not shift later audio onto the wrong turn."""
+    sys, captured = _make_system(full_audio_context=True)
+    sys.audit_log.append_user_input("[user audio]")  # turn 1 (audio)
+    sys.audit_log.append_assistant_output("resp 1")
+    sys.audit_log.append_user_input(
+        "[TURN-END FALLBACK after 10s] no user speech captured",
+        message_type="turn_fallback",
+        llm_content="[nudge: please repeat]",
+    )  # genuine-silence fallback (no audio)
+    sys.audit_log.append_assistant_output("resp 2")
+    sys.audit_log.append_user_input("[user audio]")  # turn 3 (audio, current)
+
+    # Aligned 1:1 with the three user messages: audio, None (silence fallback), audio.
+    sys._turn_audio_history = [(b"A1", 16000), None, (b"A2", 16000)]
+    sys._turn_text_hint = "HINT"
+
+    async for _ in sys._execute_agent_with_audio(sys.agent):
+        pass
+
+    users = _user_msgs(captured["messages"])
+    assert len(users) == 3
+    assert users[0]["content"][0]["_bytes"] == b"A1"
+    assert users[0]["content"][0]["hint"] == ""
+    assert users[1]["content"] == "[nudge: please repeat]"  # no-audio turn stays text, NOT audio
+    assert users[2]["content"][0]["_bytes"] == b"A2"
+    assert users[2]["content"][0]["hint"] == "HINT"
+
+
+async def test_default_mode_replaces_only_current_turn():
+    """Default (non-full) mode replaces just the last user message with the current audio."""
+    sys, captured = _make_system(full_audio_context=False)
+    sys.audit_log.append_user_input("[user audio]")
+    sys.audit_log.append_assistant_output("resp 1")
+    sys.audit_log.append_user_input("[user audio]")  # current
+    sys._turn_audio_history = [(b"A1", 16000), (b"A2", 16000)]
+    sys._turn_text_hint = "HINT"
+
+    async for _ in sys._execute_agent_with_audio(sys.agent):
+        pass
+
+    users = _user_msgs(captured["messages"])
+    assert users[0]["content"] == "[user audio]"
+    assert users[1]["content"][0]["_bytes"] == b"A2"
+    assert users[1]["content"][0]["hint"] == "HINT"
+
+
+def test_note_non_audio_turn_appends_none():
+    sys, _ = _make_system(full_audio_context=True)
+    sys.set_turn_audio(b"A1", 16000)
+    sys.note_non_audio_turn()
+    sys.set_turn_audio(b"A2", 16000)
+    assert sys._turn_audio_history == [(b"A1", 16000), None, (b"A2", 16000)]

--- a/tests/unit/assistant/test_audit_log.py
+++ b/tests/unit/assistant/test_audit_log.py
@@ -89,6 +89,17 @@ class TestAuditLog:
         self.log.append_user_input("Hi", timestamp_ms="1234567890000")
         assert self.log.transcript[0]["timestamp"] == "1234567890000"
 
+    def test_append_user_input_turn_fallback_uses_llm_content(self):
+        # Fallback markers show a plain marker in the transcript but send the nudge to the LLM.
+        self.log.append_user_input(
+            "no user speech detected within 4s",
+            message_type="turn_fallback",
+            llm_content="[please ask again]",
+        )
+        assert self.log.transcript[0]["message_type"] == "turn_fallback"
+        assert self.log.transcript[0]["value"] == "no user speech detected within 4s"
+        assert self.log.conversation_messages[0].content == "[please ask again]"
+
     def test_append_assistant_output_text(self):
         self.log.append_assistant_output("Hello!")
         assert len(self.log.transcript) == 1

--- a/tests/unit/metrics/test_processor.py
+++ b/tests/unit/metrics/test_processor.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 import pytest
 
-from eva.metrics.processor import MetricsContextProcessor, _normalize_event_for_processor, _ProcessorContext
+from eva.metrics.processor import (
+    MetricsContextProcessor,
+    _normalize_event_for_processor,
+    _ProcessorContext,
+    _validate_conversation_trace,
+)
 from eva.models.config import PipelineType
 
 FIXTURES_PATH = Path(__file__).parent.parent.parent / "fixtures" / "processor_histories.json"
@@ -69,6 +74,52 @@ class TestExtractTurnsFromHistory:
             assert actual == expected, (
                 f"Case '{case['id']}', attribute '{key}':\n  expected: {expected}\n  actual:   {actual}"
             )
+
+
+class TestValidateConversationTraceFallback:
+    """_validate_conversation_trace preserves fallback nudge entries with no matching TTS segment.
+
+    Consecutive turn-end fallback nudges can share a single merged pipecat segment on a
+    neighboring turn, leaving the second nudge's turn with no segments. Without preservation
+    the nudge is dropped, collapsing the two surrounding user turns together.
+    """
+
+    def _ctx(self, segments):
+        ctx = _ProcessorContext()
+        ctx.record_id = "test"
+        ctx._intended_assistant_segments = segments
+        ctx.intended_assistant_turns = {k: " ".join(v) for k, v in segments.items()}
+        return ctx
+
+    def test_fallback_entry_kept_when_no_segment_match(self):
+        ctx = self._ctx({4: ["I'm sorry, I didn't quite catch that."]})  # turn 5 has no segments
+        trace = [
+            {
+                "role": "assistant",
+                "content": "I'm sorry, I didn't quite catch that.",
+                "turn_id": 4,
+                "_audit_source": True,
+            },
+            {
+                "role": "assistant",
+                "content": "Are you still there?",
+                "turn_id": 5,
+                "_audit_source": True,
+                "_fallback_nudge": True,
+            },
+        ]
+        out = _validate_conversation_trace(trace, ctx)
+        assert [e["content"] for e in out] == ["I'm sorry, I didn't quite catch that.", "Are you still there?"]
+        # Bookkeeping keys are stripped from the output.
+        assert all("_fallback_nudge" not in e and "_audit_source" not in e for e in out)
+
+    def test_non_fallback_entry_still_dropped_when_unsaid(self):
+        ctx = self._ctx({4: ["I'm sorry, I didn't quite catch that."]})
+        trace = [
+            {"role": "assistant", "content": "Some text never spoken.", "turn_id": 5, "_audit_source": True},
+        ]
+        out = _validate_conversation_trace(trace, ctx)
+        assert out == []
 
 
 class TestNormalizeEventForProcessor:

--- a/tests/unit/metrics/test_turn_taking.py
+++ b/tests/unit/metrics/test_turn_taking.py
@@ -26,11 +26,13 @@ Sub-metrics (flat, one number each):
                         user_interruption.mean_yield_score (only when rate > 0)
 """
 
+import json
 import logging
 
 import pytest
 
 from eva.metrics.experience.turn_taking import TurnTakingMetric
+from eva.models.config import PipelineType
 
 from .conftest import make_metric_context
 
@@ -778,3 +780,276 @@ class TestDualInterrupt:
         assert sub["user_interruption.rate"].score == pytest.approx(1 / 3, abs=1e-4)
         assert sub["user_interruption.mean_yield_ms"].score == pytest.approx(500, abs=1)
         assert sub["user_interruption.mean_yield_score"].score == pytest.approx(0.75, abs=1e-3)
+
+
+# ---------- Pre-tool-speech lead-in rate ----------
+
+
+def _audit_assistant(ts, content):
+    return {"message_type": "assistant", "timestamp": ts, "value": content}
+
+
+def _audit_user(ts, content="hi"):
+    return {"message_type": "user", "timestamp": ts, "value": content}
+
+
+def _audit_tool_call(ts, tool="lookup"):
+    return {"message_type": "tool_call", "timestamp": ts, "value": {"tool": tool, "parameters": {}}}
+
+
+def _audit_tool_response(ts, tool="lookup"):
+    return {"message_type": "tool_response", "timestamp": ts, "value": {"tool": tool, "response": {}}}
+
+
+def _audit_llm_call(ts, response=""):
+    """An llm_call event — present in real audit logs but must not affect grouping."""
+    return {"message_type": "llm_call", "timestamp": ts, "value": {"agent": "Test Agent", "response": response}}
+
+
+def _write_audit_log(tmp_path, transcript):
+    (tmp_path / "audit_log.json").write_text(json.dumps({"transcript": transcript}))
+    return str(tmp_path)
+
+
+class TestPreToolSpeechGroups:
+    def test_no_lead_in_before_tool_call(self, metric, tmp_path):
+        """Empty assistant speech immediately before a tool call → group is False."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_assistant(2, ""),
+                _audit_tool_call(3),
+                _audit_tool_response(3),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [False]
+
+    def test_lead_in_before_tool_call(self, metric, tmp_path):
+        """Non-empty assistant speech before a tool call → group is True."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_assistant(2, "Let me pull that up."),
+                _audit_tool_call(3),
+                _audit_tool_response(3),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [True]
+
+    def test_multiple_tools_from_one_lead_in_count_as_one_group(self, metric, tmp_path):
+        """Two tool_call/tool_response pairs with no intervening speech → single group."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_assistant(2, ""),
+                _audit_tool_call(3, "confirm_swap"),
+                _audit_tool_response(3, "confirm_swap"),
+                _audit_tool_call(4, "notify_manager"),
+                _audit_tool_response(4, "notify_manager"),
+                _audit_assistant(5, "All done."),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [False]
+
+    def test_llm_call_events_do_not_break_a_group(self, metric, tmp_path):
+        """Split llm_call events should not break a tool call group.
+
+        llm_call entries (present in real audit logs) between two tool batches must be ignored,
+        not treated as a group-breaking event — regression guard for the bug where an intervening
+        llm_call incorrectly split one contiguous tool-call group into two.
+        """
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_llm_call(2, ""),
+                _audit_tool_call(2, "confirm_swap"),
+                _audit_tool_response(2, "confirm_swap"),
+                _audit_llm_call(3, ""),
+                _audit_tool_call(3, "notify_manager"),
+                _audit_tool_response(3, "notify_manager"),
+                _audit_llm_call(4, "All done."),
+                _audit_assistant(4, "All done."),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [False]
+
+    def test_user_speech_resets_lead_in_flag(self, metric, tmp_path):
+        """Assistant speech in an earlier turn doesn't count as a lead-in once the user speaks again."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_assistant(1, "Hello, how can I help?"),
+                _audit_user(2),
+                _audit_assistant(3, ""),
+                _audit_tool_call(4),
+                _audit_tool_response(4),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [False]
+
+    def test_multiple_turns_multiple_groups(self, metric, tmp_path):
+        """Mix of lead-in and no-lead-in tool groups across turns."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_assistant(2, ""),
+                _audit_tool_call(3),
+                _audit_tool_response(3),
+                _audit_assistant(4, "Verified."),
+                _audit_user(5),
+                _audit_assistant(6, "One moment."),
+                _audit_tool_call(7),
+                _audit_tool_response(7),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [False, True]
+
+    def test_out_of_order_transcript_is_sorted_by_timestamp(self, metric, tmp_path):
+        """Transcript entries out of file order are re-sorted by timestamp before grouping."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_tool_call(3),
+                _audit_user(1),
+                _audit_tool_response(3),
+                _audit_assistant(2, "Let me check."),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [True]
+
+    def test_no_tool_calls_returns_empty_list(self, metric, tmp_path):
+        output_dir = _write_audit_log(
+            tmp_path,
+            [_audit_user(1), _audit_assistant(2, "Just chatting, no tools needed.")],
+        )
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == []
+
+    def test_missing_audit_log_returns_none(self, metric, tmp_path):
+        context = make_metric_context(output_dir=str(tmp_path))
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups is None
+
+    def test_empty_transcript_returns_none(self, metric, tmp_path):
+        output_dir = _write_audit_log(tmp_path, [])
+        context = make_metric_context(output_dir=output_dir)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups is None
+
+    def test_works_for_s2s_pipeline_type(self, metric, tmp_path):
+        """Audit-log-based computation works the same regardless of pipeline_type."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_assistant(2, "Let me pull that up."),
+                _audit_tool_call(3),
+                _audit_tool_response(3),
+            ],
+        )
+        context = make_metric_context(output_dir=output_dir, pipeline_type=PipelineType.S2S)
+        groups = metric._compute_pre_tool_speech_groups(context)
+        assert groups == [True]
+
+
+class TestPreToolSpeechSubMetric:
+    @pytest.mark.asyncio
+    async def test_sub_metric_reflects_lead_in_rate(self, metric, tmp_path):
+        """2 of 4 tool-call groups have a lead-in → pretoolspeech_rate = 0.5."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_assistant(2, ""),
+                _audit_tool_call(3, "a"),
+                _audit_tool_response(3, "a"),
+                _audit_assistant(4, "Got it."),
+                _audit_user(5),
+                _audit_assistant(6, "Let me check."),
+                _audit_tool_call(7, "b"),
+                _audit_tool_response(7, "b"),
+                _audit_user(8),
+                _audit_assistant(9, "One sec."),
+                _audit_tool_call(10, "c"),
+                _audit_tool_response(10, "c"),
+                _audit_user(11),
+                _audit_assistant(12, ""),
+                _audit_tool_call(13, "d"),
+                _audit_tool_response(13, "d"),
+            ],
+        )
+        context = make_metric_context(
+            output_dir=output_dir,
+            audio_timestamps_user_turns={1: [(0.0, 1.0)]},
+            audio_timestamps_assistant_turns={1: [(1.5, 2.0)]},
+        )
+        result = await metric.compute(context)
+        sub = result.sub_metrics
+        assert sub["pretoolspeech_rate"].score == pytest.approx(0.5)
+        assert sub["pretoolspeech_rate"].normalized_score == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_sub_metric_omitted_when_no_tool_calls(self, metric, tmp_path):
+        output_dir = _write_audit_log(
+            tmp_path,
+            [_audit_user(1), _audit_assistant(2, "No tools here.")],
+        )
+        context = make_metric_context(
+            output_dir=output_dir,
+            audio_timestamps_user_turns={1: [(0.0, 1.0)]},
+            audio_timestamps_assistant_turns={1: [(1.5, 2.0)]},
+        )
+        result = await metric.compute(context)
+        assert "pretoolspeech_rate" not in result.sub_metrics
+
+    @pytest.mark.asyncio
+    async def test_sub_metric_omitted_when_audit_log_missing(self, metric, tmp_path):
+        context = make_metric_context(
+            output_dir=str(tmp_path),
+            audio_timestamps_user_turns={1: [(0.0, 1.0)]},
+            audio_timestamps_assistant_turns={1: [(1.5, 2.0)]},
+        )
+        result = await metric.compute(context)
+        assert "pretoolspeech_rate" not in result.sub_metrics
+
+    @pytest.mark.asyncio
+    async def test_sub_metric_populated_for_s2s(self, metric, tmp_path):
+        """Unlike the old trace-based approach, S2S now gets a real pretoolspeech_rate."""
+        output_dir = _write_audit_log(
+            tmp_path,
+            [
+                _audit_user(1),
+                _audit_assistant(2, "Let me check."),
+                _audit_tool_call(3),
+                _audit_tool_response(3),
+            ],
+        )
+        context = make_metric_context(
+            output_dir=output_dir,
+            audio_timestamps_user_turns={1: [(0.0, 1.0)]},
+            audio_timestamps_assistant_turns={1: [(1.5, 2.0)]},
+            pipeline_type=PipelineType.S2S,
+        )
+        result = await metric.compute(context)
+        sub = result.sub_metrics
+        assert sub["pretoolspeech_rate"].score == pytest.approx(1.0)


### PR DESCRIPTION
- Use `EVA_TURN_END_FALLBACK_TIME` to set the number of seconds to wait before nudging user
- The assistant will not nudge if user is speaking

todo:
- Small bug fix - if user is speaking or started speaking after the nudge is triggered the assistant doesn't say anything but that turn still gets counted as nudged
- Weird scenario where assistant transcript is not being captured in conversation_trace (the assistant asked if the user was still there after the vad didn't fire on the short turn)
<img width="1204" height="325" alt="Screenshot 2026-07-22 at 6 13 45 PM" src="https://github.com/user-attachments/assets/a1b4eb25-89ed-47c1-860a-61998ad1cd5e" />
from https://snow-core_llm-eva_results_analysis_plusplus.job.console.elementai.com/record_detail?output_dir=%2Fmnt%2Fvoice_agent%2Fks&record=T6.2&latest_only=false


