### PR TITLE
Refactor orchestrator runner

### DIFF
--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -154,8 +154,7 @@ class BenchmarkRunner:
         # Apply record filtering (debug mode or specific record IDs)
         filtered_records = self._filter_records(records)
 
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        (self.output_dir / "records").mkdir(exist_ok=True)
+        (self.output_dir / "records").mkdir(parents=True, exist_ok=True)
 
         # Resolve exact models used (captures defaults from services.py + any alias labels)
         if self.config.model.pipeline_type == PipelineType.CASCADE:
@@ -207,10 +206,10 @@ class BenchmarkRunner:
 
         # Pre-create ValidationRunner for per-record pipelining. Its shared MetricsRunner
         # for validation metrics is lazily initialized on first use.
-        _all_unique_records = list({id(r): r for r in output_id_to_record.values()}.values())
+        all_unique_records = list({id(r): r for r in output_id_to_record.values()}.values())
         pipeline_validation_runner = ValidationRunner(
             run_dir=self.output_dir,
-            dataset=_all_unique_records,
+            dataset=all_unique_records,
             thresholds=self.config.validation_thresholds,
             metric_configs=self._metric_configs,
         )
@@ -221,7 +220,6 @@ class BenchmarkRunner:
         metrics_background_tasks: list[asyncio.Task] = []
 
         if self.config.metrics:
-            all_unique_records = list({id(r): r for r in output_id_to_record.values()}.values())
             try:
                 metrics_runner = MetricsRunner(
                     run_dir=self.output_dir,
@@ -512,15 +510,12 @@ class BenchmarkRunner:
         # Build final_failures from the last rerun_history entry for each failed record
         final_failures: dict[str, dict] = {}
         for oid in final_failed_ids:
-            if oid in rerun_history and rerun_history[oid]:
+            if rerun_history.get(oid):
                 final_failures[oid] = rerun_history[oid][-1]
+            elif check_conversation_finished(self.output_dir / "records" / oid):
+                final_failures[oid] = {"reason": "validation_failed"}
             else:
-                # Failed on initial validation (no rerun history)
-                record_dir = self.output_dir / "records" / oid
-                if not check_conversation_finished(record_dir):
-                    final_failures[oid] = {"reason": "not_finished"}
-                else:
-                    final_failures[oid] = {"reason": "validation_failed"}
+                final_failures[oid] = {"reason": "not_finished"}
 
         llm_generic_error_record_ids = find_records_with_llm_generic_error(self.output_dir, successful_ids)
         eval_summary_path = self.output_dir / "evaluation_summary.json"
@@ -566,8 +561,8 @@ class BenchmarkRunner:
         logger.info("=" * 60)
         logger.info("Benchmark complete:")
         if total_tasks > 0:
-            logger.info(f"  Success: {successful_count}/{total_tasks} ({successful_count / total_tasks * 100:.1f}%)")
-            logger.info(f"  Failed: {failed_count}/{total_tasks} ({failed_count / total_tasks * 100:.1f}%)")
+            logger.info(f"  Success: {successful_count}/{total_tasks} ({successful_count / total_tasks:.1%})")
+            logger.info(f"  Failed: {failed_count}/{total_tasks} ({failed_count / total_tasks:.1%})")
             if not_finished_count > 0:
                 logger.info(f"    Not finished: {not_finished_count}")
             if validation_failed_count > 0:

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -447,14 +447,10 @@ class BenchmarkRunner:
         successful_ids = set(all_output_ids) - final_failed_ids
 
         # Categorize failures
-        not_finished_count = 0
-        validation_failed_count = 0
-        for oid in final_failed_ids:
-            record_dir = self.output_dir / "records" / oid
-            if not check_conversation_finished(record_dir):
-                not_finished_count += 1
-            else:
-                validation_failed_count += 1
+        not_finished_count = sum(
+            1 for oid in final_failed_ids if not check_conversation_finished(self.output_dir / "records" / oid)
+        )
+        validation_failed_count = len(final_failed_ids) - not_finished_count
 
         # STEP 7: Await background metrics, then run final aggregation pass.
         # Background tasks already wrote metrics.json for records validated during the loop.

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -256,8 +256,11 @@ class BenchmarkRunner:
                     async with semaphore:
                         result, audio_task = await self._run_conversation(record, output_id)
 
-                    # result.json is now written by the worker itself (inside the
-                    # semaphore) so it survives task cancellation and process signals.
+                    if isinstance(result, ConversationResult):
+                        result_path = self.output_dir / "records" / output_id / "result.json"
+                        if not result_path.exists():
+                            result_path.parent.mkdir(parents=True, exist_ok=True)
+                            result_path.write_text(result.model_dump_json(indent=2))
 
                     # Phase 4: Await audio task (needed for audio-based validation metrics)
                     if audio_task is not None:

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -12,7 +12,7 @@ from tqdm.asyncio import tqdm
 from tqdm.std import Bar
 
 from eva.metrics.legacy_aliases import rename_metric_keys, rename_metric_list
-from eva.metrics.runner import MetricsRunner, MetricsRunResult
+from eva.metrics.runner import MetricsRunner
 from eva.models.agents import AgentConfig
 from eva.models.config import PipelineType, RunConfig
 from eva.models.record import EvaluationRecord
@@ -189,13 +189,41 @@ class BenchmarkRunner:
                 output_id_to_record[record.id] = record
 
         all_output_ids = list(output_id_to_record.keys())
-        pending_output_ids = list(all_output_ids)
+        started_at = datetime.now()
+
+        return await self._run(
+            pending_ids=all_output_ids,
+            all_output_ids=all_output_ids,
+            output_id_to_record=output_id_to_record,
+            started_at=started_at,
+        )
+
+    async def _run(
+        self,
+        *,
+        pending_ids: list[str],
+        all_output_ids: list[str],
+        output_id_to_record: dict[str, EvaluationRecord],
+        started_at: datetime,
+        already_passed_ids: frozenset[str] = frozenset(),
+    ) -> RunResult:
+        """Run/validate/rerun every pending record, then compute metrics and write all outputs.
+
+        Single flat loop per output_id, up to max_rerun_attempts total:
+        1. Run conversation
+        2. Check conversation_finished — if not finished, retry
+        3. Run validation metrics
+        4. If validation passes → done; if not → retry
+        5. After all attempts exhausted → record is failed
+        6. Run full metrics on successful records only
+        """
+        max_attempts = self.config.max_rerun_attempts
+        pending_output_ids = list(pending_ids)
         rerun_history: dict[str, list[dict]] = {}
         time_limit_attempt_counts: dict[str, int] = {}
         time_limit_validation_cache: dict[str, dict[int, ValidationResult]] = {}
         max_time_limit_attempts = int(self.config.validation_thresholds.get("max_time_limit_attempts", 1))
         time_limit_accepted_ids: set[str] = set()
-        started_at = datetime.now()
 
         # Initialize port pool once before the attempt loop.
         await self.port_pool.initialize()
@@ -234,6 +262,7 @@ class BenchmarkRunner:
                 metrics_runner = None
 
         # LOOP: Run and validate, up to max_attempts total
+        attempt_number = 0
         for attempt_number in range(1, max_attempts + 1):
             if not pending_output_ids:
                 break
@@ -443,7 +472,7 @@ class BenchmarkRunner:
 
         # STEP 6: Compute final success/failure sets
         final_failed_ids = set(pending_output_ids)
-        successful_ids = set(all_output_ids) - final_failed_ids
+        successful_ids = (set(all_output_ids) - final_failed_ids) | already_passed_ids
 
         # Categorize failures
         not_finished_count = sum(
@@ -608,57 +637,6 @@ class BenchmarkRunner:
             # Always release port
             await self.port_pool.release(port)
 
-    async def _run_targeted(
-        self, tasks: list[tuple[EvaluationRecord, str]]
-    ) -> dict[str, ConversationResult | Exception]:
-        """Run specific (record, output_id) pairs — single attempt each, no retry.
-
-        Unlike run(), this does NOT expand records into trials
-        and does NOT retry on failure. The caller (_run_with_validation) owns
-        all retry logic via its flat loop.
-
-        Args:
-            tasks: List of (record, output_id) pairs to run.
-
-        Returns:
-            Dict mapping output_id -> ConversationResult or Exception.
-        """
-        if not tasks:
-            return {}
-
-        # Ensure output directory and port pool are ready
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        (self.output_dir / "records").mkdir(exist_ok=True)
-        await self.port_pool.initialize()
-
-        semaphore = asyncio.Semaphore(self.config.max_concurrent_conversations)
-
-        async def run_with_semaphore(record: EvaluationRecord, output_id: str) -> ConversationResult:
-            async with semaphore:
-                result, audio_task = await self._run_conversation(record, output_id)
-            # Semaphore released; await audio task outside it so the slot is free sooner.
-            if audio_task is not None:
-                try:
-                    await audio_task
-                except Exception as e:
-                    logger.warning(f"Audio save failed for {output_id}: {e}")
-            return result
-
-        coros = [run_with_semaphore(record, oid) for record, oid in tasks]
-        results = await asyncio.gather(*coros, return_exceptions=True)
-
-        output: dict[str, ConversationResult | Exception] = {}
-        for (_record, output_id), result in zip(tasks, results):
-            output[output_id] = result
-
-            # Save result.json for successful ConversationResults
-            if isinstance(result, ConversationResult):
-                result_path = self.output_dir / "records" / output_id / "result.json"
-                result_path.parent.mkdir(parents=True, exist_ok=True)
-                result_path.write_text(result.model_dump_json(indent=2))
-
-        return output
-
     async def validate_existing(
         self, run_dir: Path, records: list[EvaluationRecord], force_revalidation: bool = False
     ) -> RunResult:
@@ -688,7 +666,6 @@ class BenchmarkRunner:
         filtered_records = self._filter_records(records)
 
         # Build output_id list from config (matches _run_with_validation logic)
-        records_dir = self.output_dir / "records"
         num_trials = self.config.num_trials
         output_id_to_record: dict[str, EvaluationRecord] = {}
 
@@ -714,7 +691,7 @@ class BenchmarkRunner:
             )
 
         # Load previously successful record IDs from evaluation_summary.json
-        already_passed_ids: set[str] = set()
+        already_passed_ids: frozenset[str] = frozenset()
         if not force_revalidation:
             eval_summary_path = self.output_dir / "evaluation_summary.json"
             if eval_summary_path.exists():
@@ -722,9 +699,9 @@ class BenchmarkRunner:
                     prev_summary = json.load(f)
                 # Support both new format (nested under "simulation") and legacy flat format
                 sim = prev_summary.get("simulation", prev_summary)
-                prev_successful = set(sim.get("successful_record_ids", []))
+                prev_successful = frozenset(sim.get("successful_record_ids", []))
                 # Only skip IDs that are still present in the current output
-                already_passed_ids = prev_successful & set(all_output_ids)
+                already_passed_ids = prev_successful.intersection(all_output_ids)
                 if already_passed_ids:
                     logger.info(
                         f"Skipping validation for {len(already_passed_ids)} already-passed records "
@@ -759,197 +736,12 @@ class BenchmarkRunner:
         total_passed = newly_passed_count + len(already_passed_ids)
         logger.info(f"Validation results: {total_passed} passed, {len(failed_ids)} failed")
 
-        # STEP 3: Rerun failures using the same flat loop as _run_with_validation
-        max_attempts = self.config.max_rerun_attempts
-        rerun_history: dict[str, list[dict]] = {}
-        pending_ids = list(failed_ids)
-
-        for attempt_number in range(1, max_attempts + 1):
-            if not pending_ids:
-                break
-
-            # Archive failed outputs
-            for output_id in pending_ids:
-                self._archive_failed_attempt(output_id, attempt_number)
-
-            tasks = [(output_id_to_record[oid], oid) for oid in pending_ids]
-            run_results = await self._run_targeted(tasks)
-
-            still_not_finished: list[str] = []
-            to_validate_ids: list[str] = []
-            for output_id in pending_ids:
-                result = run_results.get(output_id)
-                if isinstance(result, Exception) or (isinstance(result, ConversationResult) and not result.completed):
-                    still_not_finished.append(output_id)
-                else:
-                    to_validate_ids.append(output_id)
-
-            failed_validation: list[str] = []
-            new_results: dict = {}
-            if to_validate_ids:
-                to_validate_records = list(
-                    {id(output_id_to_record[oid]): output_id_to_record[oid] for oid in to_validate_ids}.values()
-                )
-                vr_runner = ValidationRunner(
-                    run_dir=self.output_dir,
-                    dataset=to_validate_records,
-                    thresholds=self.config.validation_thresholds,
-                    metric_configs=self._metric_configs,
-                    output_ids=to_validate_ids,
-                )
-                new_results = await vr_runner.run_validation()
-                for output_id in to_validate_ids:
-                    vr = new_results.get(output_id)
-                    if vr is None or (not vr.passed and not vr.failed_metrics):
-                        still_not_finished.append(output_id)
-                    elif not vr.passed:
-                        failed_validation.append(output_id)
-
-            pending_ids = still_not_finished + failed_validation
-            for oid in still_not_finished:
-                rerun_history.setdefault(oid, []).append(
-                    {
-                        "attempt": attempt_number,
-                        "reason": "not_finished",
-                    }
-                )
-            for oid in failed_validation:
-                vr = new_results[oid]
-                entry: dict = {
-                    "attempt": attempt_number,
-                    "reason": "validation_failed",
-                    "failed_metrics": vr.failed_metrics,
-                    "scores": vr.scores,
-                }
-                if vr.details:
-                    failure_details = {name: vr.details[name] for name in vr.failed_metrics if name in vr.details}
-                    if failure_details:
-                        entry["failure_details"] = failure_details
-                rerun_history.setdefault(oid, []).append(entry)
-
-            if not pending_ids:
-                logger.info("All rerun records now pass validation!")
-                break
-
-        if pending_ids:
-            logger.warning(f"{len(pending_ids)} tasks still failing after {max_attempts} attempts")
-
-        # STEP 4: Optionally run metrics
-        final_failed_ids = set(pending_ids)
-        successful_ids = (set(all_output_ids) - final_failed_ids) | already_passed_ids
-
-        metrics_result: MetricsRunResult | None = None
-        if self.config.metrics and successful_ids:
-            logger.info(f"Running metrics on {len(successful_ids)} successful records...")
-            successful_records = list(
-                {id(output_id_to_record[oid]): output_id_to_record[oid] for oid in successful_ids}.values()
-            )
-            metrics_runner = MetricsRunner(
-                run_dir=self.output_dir,
-                dataset=successful_records,
-                metric_names=self.config.metrics,
-                metric_configs=self._metric_configs,
-                record_ids=list(successful_ids),
-                num_draws=self.config.num_trials,
-                force_rerun=self.config.force_rerun_metrics,
-            )
-            metrics_result = await metrics_runner.run()
-        elif self.config.metrics and not successful_ids:
-            logger.info("Skipping metrics: no records passed validation")
-
-        # STEP 5: Generate summary
-        ended_at = datetime.now()
-        total = len(all_output_ids)
-
-        # Categorize final failures
-        not_finished_count = sum(1 for oid in final_failed_ids if not check_conversation_finished(records_dir / oid))
-        validation_failed_count = len(final_failed_ids) - not_finished_count
-
-        # Build final_failures from the last rerun_history entry for each failed record
-        final_failures: dict[str, dict] = {}
-        for oid in final_failed_ids:
-            if oid in rerun_history and rerun_history[oid]:
-                final_failures[oid] = rerun_history[oid][-1]
-            else:
-                # Failed on initial validation (no rerun history)
-                if not check_conversation_finished(records_dir / oid):
-                    final_failures[oid] = {"reason": "not_finished"}
-                else:
-                    vr = validation_results.get(oid)
-                    entry: dict = {
-                        "reason": "validation_failed",
-                        "failed_metrics": vr.failed_metrics if vr else [],
-                        "scores": vr.scores if vr else {},
-                    }
-                    if vr and vr.details:
-                        failure_details = {}
-                        for metric_name in vr.failed_metrics:
-                            if metric_name in vr.details:
-                                failure_details[metric_name] = vr.details[metric_name]
-                        if failure_details:
-                            entry["failure_details"] = failure_details
-                    final_failures[oid] = entry
-
-        # Archive the final failing attempts so the directory layout reflects the
-        # failure (downstream tools key off the `_failed_attempt_` suffix).
-        for oid in final_failed_ids:
-            self._archive_failed_attempt(oid, max_attempts)
-
-        # Build evaluation summary with separate simulation and metrics sections
-        llm_generic_error_record_ids = find_records_with_llm_generic_error(self.output_dir, successful_ids)
-        eval_summary: dict[str, Any] = {
-            "started_at": started_at.isoformat(),
-            "ended_at": ended_at.isoformat(),
-            "duration_seconds": (ended_at - started_at).total_seconds(),
-            "simulation": {
-                "total_records": total,
-                "successful_records": len(successful_ids),
-                "failed_records": len(final_failed_ids),
-                "not_finished_count": not_finished_count,
-                "validation_failed_count": validation_failed_count,
-                "records_with_llm_generic_error": len(llm_generic_error_record_ids),
-                "llm_generic_error_record_ids": llm_generic_error_record_ids,
-                "failed_record_ids": sorted(final_failed_ids),
-                "successful_record_ids": sorted(successful_ids),
-            },
-            "rerun_history": rerun_history,
-            "final_failures": final_failures,
-        }
-
-        eval_summary_path = self.output_dir / "evaluation_summary.json"
-        with open(eval_summary_path, "w") as f:
-            json.dump(eval_summary, f, indent=2, ensure_ascii=False)
-
-        # Terminal output — clearly separate simulation from metrics
-        logger.info("=" * 60)
-        logger.info("EVALUATION COMPLETE")
-        logger.info("=" * 60)
-        logger.info("Simulation:")
-        logger.info(f"  Successful: {len(successful_ids)}/{total}")
-        if final_failed_ids:
-            logger.info(f"  Failed: {len(final_failed_ids)}/{total}")
-
-        if self.config.metrics:
-            logger.info("Metrics:")
-            if metrics_result is None:
-                logger.info("  Skipped (no records passed simulation validation)")
-            elif metrics_result.has_metric_failures:
-                logger.error(
-                    f"  {metrics_result.total_metric_failures} metric computation(s) failed "
-                    f"across {len(metrics_result.metric_failures)} metric(s): "
-                    f"{', '.join(metrics_result.metric_failures.keys())}"
-                )
-                logger.info("  See METRICS RESULTS above and metrics_summary.json for details.")
-            else:
-                logger.info(f"  All metrics computed successfully on {metrics_result.total_records} records.")
-        logger.info("=" * 60)
-
-        return RunResult(
-            run_id=self.config.run_id,
-            total_records=total,
-            successful_records=len(successful_ids),
-            failed_records=len(final_failed_ids),
-            duration_seconds=(ended_at - started_at).total_seconds(),
+        return await self._run(
+            pending_ids=failed_ids,
+            all_output_ids=all_output_ids,
+            output_id_to_record=output_id_to_record,
+            started_at=started_at,
+            already_passed_ids=already_passed_ids,
         )
 
     async def rerun_failed_metrics(

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -259,12 +259,6 @@ class BenchmarkRunner:
                     # result.json is now written by the worker itself (inside the
                     # semaphore) so it survives task cancellation and process signals.
 
-                    # Phase 2: If the conversation didn't complete, skip validation.
-                    # validate_one() handles the gate (conversation_valid_end); returning
-                    # vr=None signals "not_finished" to the classification loop below.
-                    if not (isinstance(result, ConversationResult) and result.completed):
-                        return output_id, result, False, None
-
                     # Phase 4: Await audio task (needed for audio-based validation metrics)
                     if audio_task is not None:
                         try:

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -238,6 +238,11 @@ class BenchmarkRunner:
             if not pending_output_ids:
                 break
 
+            # Archive each record's prior output (numbered for the attempt that produced it,
+            # attempt_number - 1, keeping _failed_attempt_N aligned with the time-limit cache).
+            for oid in pending_output_ids:
+                self._archive_failed_attempt(oid, attempt_number - 1)
+
             # STEPS 1-3: Per-record pipeline — run, validate, and fire metrics as each
             # conversation completes rather than waiting for the full batch.
             # The semaphore slot is released before audio writes and before LLM validation
@@ -435,12 +440,9 @@ class BenchmarkRunner:
             if not pending_output_ids:
                 logger.info("All tasks passed validation!")
                 break
-            elif attempt_number < max_attempts:
-                logger.info(f"Archiving {len(pending_output_ids)} failed tasks for rerun...")
-                for output_id in pending_output_ids:
-                    self._archive_failed_attempt(output_id, attempt_number)
-            else:
-                logger.warning(f"{len(pending_output_ids)} tasks still failing after {max_attempts} attempts")
+
+        if pending_output_ids:
+            logger.warning(f"{len(pending_output_ids)} tasks still failing after {max_attempts} attempts")
 
         # STEP 6: Compute final success/failure sets
         final_failed_ids = set(pending_output_ids)

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -305,7 +305,6 @@ class BenchmarkRunner:
             # vr=None → crash/incomplete (not_finished).
             # vr.passed=False + empty failed_metrics → gate rejected (not_finished).
             # vr.passed=False + non-empty failed_metrics → LLM metrics failed (validation_failed).
-            finished_ids: list[str] = []
             not_finished_ids: list[str] = []
             failed_validation_ids: list[str] = []
             validation_results: dict[str, ValidationResult] = {}
@@ -316,11 +315,9 @@ class BenchmarkRunner:
                     result_map[output_id] = _result
                 if vr is None or (not vr.passed and not vr.failed_metrics):
                     not_finished_ids.append(output_id)
-                else:
-                    finished_ids.append(output_id)
-                    if not passed:
-                        failed_validation_ids.append(output_id)
-                        validation_results[output_id] = vr
+                elif not passed:
+                    failed_validation_ids.append(output_id)
+                    validation_results[output_id] = vr
 
             if not_finished_ids:
                 logger.info(
@@ -381,7 +378,6 @@ class BenchmarkRunner:
                     self._accept_time_limit_record(
                         oid,
                         failed_this_attempt,
-                        finished_ids,
                         newly_time_limit_accepted,
                         metrics_runner,
                         metrics_background_tasks,
@@ -412,7 +408,6 @@ class BenchmarkRunner:
                             self._accept_time_limit_record(
                                 oid,
                                 failed_this_attempt,
-                                finished_ids,
                                 newly_time_limit_accepted,
                                 metrics_runner,
                                 metrics_background_tasks,
@@ -1156,14 +1151,12 @@ class BenchmarkRunner:
         self,
         oid: str,
         failed_this_attempt: list[str],
-        finished_ids: list[str],
         newly_time_limit_accepted: list[str],
         metrics_runner: MetricsRunner | None,
         metrics_background_tasks: list[asyncio.Task],
     ) -> None:
         """Accept a time-limit record by updating result.json and scheduling metrics."""
         failed_this_attempt.remove(oid)
-        finished_ids.append(oid)
         newly_time_limit_accepted.append(oid)
         # Update result.json with time_limit_accepted flag
         result_path = self.output_dir / "records" / oid / "result.json"

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -528,9 +528,6 @@ class BenchmarkRunner:
                         "validation_failed_count": validation_failed_count,
                         "records_with_llm_generic_error": len(llm_generic_error_record_ids),
                         "llm_generic_error_record_ids": llm_generic_error_record_ids,
-                        "success_rate": successful_count / total_tasks if total_tasks > 0 else 0.0,
-                        "failure_rate": failed_count / total_tasks if total_tasks > 0 else 0.0,
-                        "total_attempts": attempt_number,
                         "failed_record_ids": sorted(final_failed_ids),
                         "successful_record_ids": sorted(successful_ids),
                         "time_limit_accepted_record_ids": sorted(time_limit_accepted_ids),
@@ -539,6 +536,7 @@ class BenchmarkRunner:
                     "final_failures": final_failures,
                 },
                 f,
+                ensure_ascii=False,
                 indent=2,
             )
 
@@ -916,23 +914,12 @@ class BenchmarkRunner:
                 "validation_failed_count": validation_failed_count,
                 "records_with_llm_generic_error": len(llm_generic_error_record_ids),
                 "llm_generic_error_record_ids": llm_generic_error_record_ids,
-                "total_rerun_attempts": max(len(v) for v in rerun_history.values()) if rerun_history else 0,
                 "failed_record_ids": sorted(final_failed_ids),
                 "successful_record_ids": sorted(successful_ids),
             },
             "rerun_history": rerun_history,
             "final_failures": final_failures,
         }
-
-        if metrics_result is not None:
-            eval_summary["metrics"] = {
-                "records_evaluated": metrics_result.total_records,
-                "metrics_computed": self.config.metrics,
-                "total_metric_failures": metrics_result.total_metric_failures,
-                "metric_failures": {
-                    name: sorted(record_ids) for name, record_ids in metrics_result.metric_failures.items()
-                },
-            }
 
         eval_summary_path = self.output_dir / "evaluation_summary.json"
         with open(eval_summary_path, "w") as f:

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -324,7 +324,7 @@ class BenchmarkRunner:
             pipeline_results = await tqdm.gather(
                 *(_run_and_pipeline(output_id_to_record[oid], oid) for oid in pending_output_ids),
                 total=len(pending_output_ids),
-                desc=f"Attempt {attempt_number}/{max_attempts}",
+                desc=f"Progress on {self.config.run_id} attempt {attempt_number}/{max_attempts}",
                 file=TqdmNewlineStream(sys.stderr),
                 mininterval=0,
                 unit="task",

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -456,11 +456,6 @@ class BenchmarkRunner:
             else:
                 validation_failed_count += 1
 
-        # Archive the final failing attempts so the directory layout reflects the
-        # failure (downstream tools key off the `_failed_attempt_` suffix).
-        for oid in final_failed_ids:
-            self._archive_failed_attempt(oid, attempt_number)
-
         # STEP 7: Await background metrics, then run final aggregation pass.
         # Background tasks already wrote metrics.json for records validated during the loop.
         # IMPORTANT: Must await all background tasks BEFORE mutating metrics_runner.record_ids
@@ -511,6 +506,11 @@ class BenchmarkRunner:
                 final_failures[oid] = {"reason": "validation_failed"}
             else:
                 final_failures[oid] = {"reason": "not_finished"}
+
+        # Archive the final failing attempts so the directory layout reflects the
+        # failure (downstream tools key off the `_failed_attempt_` suffix).
+        for oid in final_failed_ids:
+            self._archive_failed_attempt(oid, attempt_number)
 
         llm_generic_error_record_ids = find_records_with_llm_generic_error(self.output_dir, successful_ids)
         eval_summary_path = self.output_dir / "evaluation_summary.json"

--- a/tests/integration/test_evaluation_mode.py
+++ b/tests/integration/test_evaluation_mode.py
@@ -399,10 +399,11 @@ async def test_evaluation_mode_with_unresolved_errors(eval_config, mock_dataset)
     def completed_fn(record_id, per_record_attempt):
         return record_id != "fail_record_1"
 
-    validation_results = create_mock_validation_results(
-        pass_ids=["pass_record_1"],
-        fail_ids=[],
-    )
+    # An incomplete conversation is rejected by validate_one's gate, which it signals as passed=False with empty failed_metrics.
+    validation_results = {
+        "pass_record_1": ValidationResult(passed=True),
+        "fail_record_1": ValidationResult(passed=False),
+    }
 
     with patch.object(
         runner, "_run_conversation", side_effect=_mock_run_conversation_helper(runner, call_counts, completed_fn)

--- a/tests/integration/test_evaluation_mode.py
+++ b/tests/integration/test_evaluation_mode.py
@@ -212,7 +212,6 @@ async def test_evaluation_mode_all_pass_first_attempt(eval_config, mock_dataset)
                 assert sim["total_records"] == 2
                 assert sim["successful_records"] == 2
                 assert sim["failed_records"] == 0
-                assert sim["total_attempts"] == 1
 
 
 @pytest.mark.asyncio
@@ -254,7 +253,6 @@ async def test_evaluation_mode_rerun_failures(eval_config, mock_dataset):
             with open(eval_summary_path) as f:
                 eval_summary = json.load(f)
                 sim = eval_summary["simulation"]
-                assert sim["total_attempts"] == 2
                 assert sim["successful_records"] == 2
 
             # Check that failed attempt was archived
@@ -299,7 +297,6 @@ async def test_evaluation_mode_max_reruns_reached(eval_config, mock_dataset):
             with open(eval_summary_path) as f:
                 eval_summary = json.load(f)
                 sim = eval_summary["simulation"]
-                assert sim["total_attempts"] == 3
                 assert sim["successful_records"] == 1
                 assert sim["failed_records"] == 1
                 assert "fail_record_1" in sim["failed_record_ids"]


### PR DESCRIPTION
* [Clean up (trivial)](https://github.com/ServiceNow/eva/pull/193/commits/96a345b7f83ec5c841a71aa1323e276a3a3ab86f)
* [Remove unused `finished_ids`](https://github.com/ServiceNow/eva/pull/193/commits/50d986761231e7795b1a22c2110eacd90e870f04)
* Bring `run()` (normal run) on par with `validate_existing()` (rerun)
  * [Sync `evaluation_summary.json` between `run()` and `validate_existing()`](https://github.com/ServiceNow/eva/pull/193/commits/ddc37e005a8d8c3f2c4aa406bbc13e188d6b0562) by removing fields that are not present in both (so I guess they were not important, but I'm happy to restore any if you want), and allowing non-ASCII characters (which was only the case in `validate_existing()`).
    * [Adapt test](https://github.com/ServiceNow/eva/pull/193/commits/0a24f74110f07394843c16e21e77c796db50e222)
  * [Archive the final failing attempts after the last `check_conversation_finished()`](https://github.com/ServiceNow/eva/pull/193/commits/b894a6f71d1094322c60e7ceb1d14c5f1c7134b3) in `run()` like it's done in `validate_existing()`. In practice, this `check_conversation_finished()` was not reachable because failed records always had an entry in `rerun_history`, but that seemed fragile.
  * [Simplify categorizing failures](https://github.com/ServiceNow/eva/pull/193/commits/dc10c2ed6ccbfee16c90463e7ccf057c42d4180f) in `run()` like it's done in `validate_existing()`.
  * [Archive at the beginning of the attempt loop](https://github.com/ServiceNow/eva/pull/193/commits/a0726341973269f4a5de70eb9b41a1c108794a8d) in `run()` like it's done in `validate_existing()`.
  * [Always await audio for incomplete conversations](https://github.com/ServiceNow/eva/pull/193/commits/208b8c860197b74bdf3228352ba026808012fa6f) 
    Remove the early-return for incomplete conversations in `_run_and_pipeline()`. It returned before `await audio_task`, leaving the audio task running un-awaited. The pipeline then proceeded without flushing the WAV and any exception went unobserved. This mattered most for `time_limit_exceeded` records, which are later skip-gate validated and can be accepted, so their audio must be written first.

    Classification is unchanged: an unfinished conversation still fails the `conversation_valid_end` gate in `validate_one()` and is bucketed `not_finished`.
    * [Adapt test](https://github.com/ServiceNow/eva/pull/193/commits/56e5bea5bd3180ca37b6ccadc69b43af7c8da405)
  * [Write `result.json` fallback when the worker skips it](https://github.com/ServiceNow/eva/pull/193/commits/ec9da6deec4a633a21ca0256769ac76b38c88f9e) 
    The worker writes `result.json` itself on the happy path, but its post-processing-exception path returns a result without writing, relying on the runner to do it. The worker code includes this comment:
    ```
    # Return a failed result so result.json still gets written by the
    # runner, rather than raising and leaving no result.json on disk.
    ```
    But, `run()` didn't actually write it, until now.
* [Share code between `run()` and `validate_existing()`](https://github.com/ServiceNow/eva/pull/193/commits/9865b4724722534821b819d5e1add81db85a5c21) 
    Extract `run()`'s attempt loop into `_run()` and reuse it in `validate_existing()`. This removes duplicated code, and `validate_existing()` gains a few features that only `run()` had:

    - per-record pipelining: metrics fire as soon as a conversation completes instead of waiting for all conversations to complete.
    - time-limit acceptance (added as "timeout" acceptance in b723a0fb, then renamed to "time-limit" in 1a427867) now also applies during reruns, not just the initial `run_validation()` pass.
    - a progress bar
* [Add run_id to progress bar description](https://github.com/ServiceNow/eva/pull/193/commits/82bf3bd0bc1d817ce9990417d625748af6554e05) so we can differentiate multiple runs launched at once.