### PR TITLE
alias collision fix

### DIFF
--- a/data/itsm_aliases/executive_garage.json
+++ b/data/itsm_aliases/executive_garage.json
@@ -3,9 +3,7 @@
   "translatable": true,
   "base": [
     "executive garage",
-    "exec garage",
-    "main garage",
-    "executive <last_name>ing"
+    "exec garage"
   ],
   "translations": {
     "fr": [
@@ -34,7 +32,6 @@
       "aparcamiento ejecutivo",
       "garaje de dirección",
       "garaje ejecutivo",
-      "garaje principal",
       "parking ejecutivo"
     ],
     "de": [
@@ -45,21 +42,17 @@
     "hi": [
       "एक्जेक गैराज",
       "एग्जीक्यूटिव गैराज",
-      "एग्जीक्यूटिव पार्किंग",
-      "मुख्य गैराज"
+      "एग्जीक्यूटिव पार्किंग"
     ],
     "ko": [
-      "메인 주차장",
       "임원 주차동",
       "임원 주차장",
       "임원용 차고"
     ],
     "ja": [
       "エグゼクティブガレージ",
-      "メイン駐車場",
       "幹部用駐車場",
-      "役員用駐車場",
-      "メインガレージ"
+      "役員用駐車場"
     ],
     "it": [
       "autorimessa dirigenti",

--- a/src/eva/utils/culture.py
+++ b/src/eva/utils/culture.py
@@ -335,6 +335,14 @@ def _inject_aliases(obj: Any, index: dict[str, dict], language: str) -> None:
 
     ``name_aliases`` = base + ``translations[language]`` (deduped, order-preserved).
     Other dicts/lists are recursed into. Entries whose ``name`` is unknown are left alone.
+
+    Alias files have no cross-entity dedup, so two different entities can share the same
+    phrase (e.g. "main garage"). That's only a *dormant* collision if they never appear
+    in the same scenario DB — this function injects aliases per-entry, so ``_match_alias``
+    (itsm_tools.py) never sees the other entity's aliases. It's an *active* collision, and
+    a real bug, only when both entities live in the same scenario DB — then whichever one
+    matches first wins, silently. Existing itsm data is frozen, so dormant collisions
+    there are safe to leave. For new domains/entities, avoid active collisions.
     """
     if isinstance(obj, dict):
         name = obj.get("name")


### PR DESCRIPTION
one entity had conflicting aliases. Many others also do, but due to the way we only load the relevant entities per scenario, it was only active in one of the records. That is fixed and noted. Data doesn't really change much, so it should be safe to leave these dormant collisions in as long as the future data handles this appropriately.