### PR TITLE
Support overriding metric configs

### DIFF
--- a/src/eva/models/config.py
+++ b/src/eva/models/config.py
@@ -13,6 +13,7 @@ and explicit kwargs.  Scripts opt in to ``.env`` and/or CLI via
 """
 
 import copy
+import json
 import logging
 import os
 from collections.abc import Iterator
@@ -609,6 +610,18 @@ class RunConfig(BaseSettings):
     metrics: list[str] | None = Field(
         default_factory=_get_all_metrics,
         description="Metrics to run. Skip all metrics with `EVA_METRICS=` or `--metrics=`.",
+    )
+
+    metric_configs: dict[str, dict[str, Any]] = Field(
+        {},
+        description=(
+            "Per-metric configuration overrides (JSON), keyed by metric name. For judge metrics "
+            "(TextJudgeMetric/AudioJudgeMetric subclasses), 'judge_model' overrides the model "
+            "and 'judge_params' merges into the LLM call params (e.g. reasoning_effort, temperature). "
+            f"Example: EVA_METRIC_CONFIGS='{json.dumps({'faithfulness': {'judge_model': 'gpt-5.6-terra', 'judge_params': {'reasoning_effort': 'none'}}})}' "
+            "or EVA_METRIC_CONFIGS__FAITHFULNESS__JUDGE_MODEL=gpt-5.6-terra "
+            "or EVA_METRIC_CONFIGS__FAITHFULNESS__JUDGE_PARAMS__REASONING_EFFORT=none."
+        ),
     )
 
     # Aggregate-only mode

--- a/src/eva/orchestrator/runner.py
+++ b/src/eva/orchestrator/runner.py
@@ -1,6 +1,7 @@
 """Benchmark runner - main orchestrator for running voice agent benchmarks."""
 
 import asyncio
+import copy
 import json
 import shutil
 import sys
@@ -77,14 +78,21 @@ class BenchmarkRunner:
             pool_size=config.port_pool_size,
         )
 
-        # Per-metric configuration derived from run config (e.g. language for stt_wer).
-        self._metric_configs: dict[str, dict] = {
-            "stt_wer": {"language": config.language.value},
-        }
-
         # Results tracking
         self._results: list[ConversationResult] = []
         self._failed_record_ids: list[str] = []
+
+    @property
+    def _metric_configs(self) -> dict[str, dict]:
+        """Per-metric configuration: language for stt_wer, plus any user-supplied overrides.
+
+        Computed from `self.config` on each access (rather than cached at construction time)
+        so that CLI overrides applied to `runner.config.metric_configs` after
+        `from_existing_run()` (in run_benchmark.py) take effect.
+        """
+        metric_configs: dict[str, dict] = copy.deepcopy(self.config.metric_configs)
+        metric_configs.setdefault("stt_wer", {}).setdefault("language", self.config.language.value)
+        return metric_configs
 
     def _load_agent_config(self) -> AgentConfig:
         """Load single agent configuration; append the language addendum once."""

--- a/src/eva/run_benchmark.py
+++ b/src/eva/run_benchmark.py
@@ -55,6 +55,8 @@ async def run_benchmark(config: RunConfig) -> int:
         runner.config.preflight_timeout_seconds = config.preflight_timeout_seconds
         if config.metrics is not None:
             runner.config.metrics = config.metrics
+        if config.metric_configs:
+            runner.config.metric_configs = config.metric_configs
 
         dataset_path = runner.config.dataset_path
 

--- a/tests/unit/models/test_config_models.py
+++ b/tests/unit/models/test_config_models.py
@@ -707,6 +707,25 @@ class TestExecutionSettings:
         c = _config(env_vars=_BASE_ENV | {"EVA_MODEL__STT_PARAMS": json.dumps(params)})
         assert c.model.stt_params == params
 
+    def test_metric_configs_default_is_empty(self):
+        c = _config(env_vars=_BASE_ENV)
+        assert c.metric_configs == {}
+
+    def test_metric_configs_via_json_env_var(self):
+        expected = {"faithfulness": {"judge_model": "gpt-5.6-terra", "judge_params": {"reasoning_effort": "none"}}}
+        c = _config(env_vars=_BASE_ENV | {"EVA_METRIC_CONFIGS": json.dumps(expected)})
+        assert c.metric_configs == expected
+
+    def test_metric_configs_via_nested_env_vars(self):
+        env_vars = {
+            "EVA_METRIC_CONFIGS__FAITHFULNESS__JUDGE_MODEL": "gpt-5.6-terra",
+            "EVA_METRIC_CONFIGS__FAITHFULNESS__JUDGE_PARAMS__REASONING_EFFORT": "none",
+        }
+        c = _config(env_vars=_BASE_ENV | env_vars)
+        assert c.metric_configs == {
+            "faithfulness": {"judge_model": "gpt-5.6-terra", "judge_params": {"reasoning_effort": "none"}}
+        }
+
     def test_tts_params(self):
         params = {"api_key": "k", "model": "sonic", "voice": "alloy", "speed": 1.2}
         c = _config(env_vars=_BASE_ENV | {"EVA_MODEL__TTS_PARAMS": json.dumps(params)})

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -181,6 +181,59 @@ class TestSaveResultsCsv:
         assert "record_id" in lines[0]
 
 
+class TestMetricConfigs:
+    def test_defaults_to_stt_wer_language_only(self, tmp_path):
+        config = _make_config(tmp_path)
+        runner = _make_runner(config)
+
+        assert runner._metric_configs == {"stt_wer": {"language": "en"}}
+
+    def test_merges_user_overrides_without_touching_stt_wer(self, tmp_path):
+        config = _make_config(tmp_path).model_copy(
+            update={
+                "metric_configs": {
+                    "faithfulness": {
+                        "judge_model": "potato",
+                        "judge_params": {"reasoning_effort": "herculean"},
+                    }
+                }
+            }
+        )
+        runner = _make_runner(config)
+
+        assert runner._metric_configs == {
+            "stt_wer": {"language": "en"},
+            "faithfulness": {
+                "judge_model": "potato",
+                "judge_params": {"reasoning_effort": "herculean"},
+            },
+        }
+
+    def test_user_override_of_stt_wer_language_wins(self, tmp_path):
+        config = _make_config(tmp_path).model_copy(update={"metric_configs": {"stt_wer": {"language": "fr"}}})
+        runner = _make_runner(config)
+
+        assert runner._metric_configs["stt_wer"] == {"language": "fr"}
+
+    def test_does_not_mutate_stored_config(self, tmp_path):
+        """The returned dict must not alias self.config.metric_configs's nested dicts."""
+        config = _make_config(tmp_path).model_copy(update={"metric_configs": {"faithfulness": {}}})
+        runner = _make_runner(config)
+
+        runner._metric_configs["faithfulness"]["judge_model"] = "mutated"
+
+        assert config.metric_configs["faithfulness"] == {}
+
+    def test_reflects_config_changes_made_after_construction(self, tmp_path):
+        """Mirrors run_benchmark.py applying a CLI override onto runner.config post-construction."""
+        config = _make_config(tmp_path)
+        runner = _make_runner(config)
+
+        runner.config.metric_configs = {"faithfulness": {"judge_model": "potato"}}
+
+        assert runner._metric_configs["faithfulness"] == {"judge_model": "potato"}
+
+
 class TestFromExistingRun:
     @patch.dict(os.environ, _BASE_ENV, clear=True)
     def test_sets_output_dir_to_run_dir(self, tmp_path):


### PR DESCRIPTION
Support overriding metric configs via CLI arguments or environment variables.

Examples:

`EVA_METRIC_CONFIGS='{"faithfulness": {"judge_model": "gpt-5.6-terra", "judge_params": {"reasoning_effort": "none"}}}'`
`EVA_METRIC_CONFIGS__FAITHFULNESS__JUDGE_MODEL=gpt-5.6-terra`
`EVA_METRIC_CONFIGS__FAITHFULNESS__JUDGE_PARAMS__REASONING_EFFORT=none`